### PR TITLE
Add additional yaku coverage tests

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -424,7 +424,7 @@ pub fn judge_yaku(tiles: &[TileName], ctx: WinContext) -> HashSet<YakuId> {
         }
     }
 
-    if let Some(p) = patterns.get(0) {
+    if let Some(p) = patterns.first() {
         if contains_yakuhai(&counts, ctx.seat_wind) {
             if counts[TileName::White as usize] >= 3 {
                 result.insert(YakuId::YakuhaiHaku);
@@ -609,7 +609,7 @@ fn generate_patterns(counts: &[usize; 35]) -> Vec<HandPattern> {
         if counts[i] < 2 {
             continue;
         }
-        let mut working = counts.clone();
+        let mut working = *counts;
         working[i] -= 2;
         let pair = TileName::from_usize(i);
         let mut melds = Vec::new();
@@ -666,18 +666,22 @@ fn search_melds(
             let next2 = i + 2;
             if let Some((s1, r1)) = is_number_tile(TileName::from_usize(next1)) {
                 if let Some((s2, r2)) = is_number_tile(TileName::from_usize(next2)) {
-                    if s1 == suit && s2 == suit && r1 == rank + 1 && r2 == rank + 2 {
-                        if counts[next1] > 0 && counts[next2] > 0 {
-                            counts[i] -= 1;
-                            counts[next1] -= 1;
-                            counts[next2] -= 1;
-                            melds.push(MeldKind::Sequence(tile));
-                            search_melds(counts, melds, patterns, pair);
-                            melds.pop();
-                            counts[i] += 1;
-                            counts[next1] += 1;
-                            counts[next2] += 1;
-                        }
+                    if s1 == suit
+                        && s2 == suit
+                        && r1 == rank + 1
+                        && r2 == rank + 2
+                        && counts[next1] > 0
+                        && counts[next2] > 0
+                    {
+                        counts[i] -= 1;
+                        counts[next1] -= 1;
+                        counts[next2] -= 1;
+                        melds.push(MeldKind::Sequence(tile));
+                        search_melds(counts, melds, patterns, pair);
+                        melds.pop();
+                        counts[i] += 1;
+                        counts[next1] += 1;
+                        counts[next2] += 1;
                     }
                 }
             }

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -69,4 +69,93 @@ mod tests {
         let result = judge_yaku(&tiles, WinContext::default());
         assert!(result.contains(&YakuId::SanshokuDoujun));
     }
+
+    #[test]
+    fn detect_ipeiko() {
+        let tiles = vec![
+            OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, // double 123m
+            FourP, FiveP, SixP, // 456p
+            SevenS, EightS, NineS, // 789s
+            FiveS, FiveS, // pair
+        ];
+
+        let result = judge_yaku(&tiles, WinContext::default());
+        assert!(result.contains(&YakuId::Ipeiko));
+    }
+
+    #[test]
+    fn detect_ryanpeiko() {
+        let tiles = vec![
+            OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, // double 123m
+            FourM, FourM, FiveM, FiveM, SixM, SixM, // double 456m
+            SevenM, SevenM, // pair
+        ];
+
+        let result = judge_yaku(&tiles, WinContext::default());
+        assert!(result.contains(&YakuId::Ryanpeiko));
+    }
+
+    #[test]
+    fn detect_yakuhai_with_seat_and_round_wind() {
+        let tiles = vec![
+            East, East, East, // seat/round wind triplet
+            South, South, South, // additional triplet
+            OneM, TwoM, ThreeM, // 123m
+            FourP, FiveP, SixP, // 456p
+            NineS, NineS, // pair
+        ];
+
+        let ctx = WinContext {
+            seat_wind: Some(East),
+            round_wind: Some(East),
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, ctx);
+        assert!(result.contains(&YakuId::YakuhaiJikaze));
+        assert!(result.contains(&YakuId::YakuhaiBakaze));
+    }
+
+    #[test]
+    fn detect_honitsu() {
+        let tiles = vec![
+            OneM, TwoM, ThreeM, // 123m
+            FourM, FiveM, SixM, // 456m
+            SevenM, EightM, NineM, // 789m
+            OneM, OneM, OneM, // 111m
+            White, White, // pair
+        ];
+
+        let result = judge_yaku(&tiles, WinContext::default());
+        assert!(result.contains(&YakuId::Honitsu));
+        assert!(result.contains(&YakuId::YakuhaiHaku));
+    }
+
+    #[test]
+    fn detect_sanshoku_doukou() {
+        let tiles = vec![
+            FiveM, FiveM, FiveM, // 555m
+            FiveP, FiveP, FiveP, // 555p
+            FiveS, FiveS, FiveS, // 555s
+            OneM, TwoM, ThreeM, // 123m
+            East, East, // pair
+        ];
+
+        let result = judge_yaku(&tiles, WinContext::default());
+        assert!(result.contains(&YakuId::SanshokuDoukou));
+    }
+
+    #[test]
+    fn detect_chinroutou() {
+        let tiles = vec![
+            OneM, OneM, OneM, // 111m
+            NineM, NineM, NineM, // 999m
+            OneP, OneP, OneP, // 111p
+            NineS, NineS, NineS, // 999s
+            OneS, OneS, // pair
+        ];
+
+        let result = judge_yaku(&tiles, WinContext::default());
+        assert!(result.contains(&YakuId::Chinroutou));
+        assert!(result.contains(&YakuId::Honroutou));
+    }
 }

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -127,7 +127,6 @@ mod tests {
 
         let result = judge_yaku(&tiles, WinContext::default());
         assert!(result.contains(&YakuId::Honitsu));
-        assert!(result.contains(&YakuId::YakuhaiHaku));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add individual unit tests for additional yaku combinations such as ipeiko, ryanpeiko, yakuhai, honitsu, sanshoku doukou, and chinroutou

## Testing
- cargo test *(fails: missing libpython3.11.so.1.0 in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2a50db3c832bafa27fadd21bf1e1)