### PR TITLE
Fix Ipeiko detection to allow non-sequence melds

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -734,9 +734,6 @@ fn has_ipeiko(patterns: &[HandPattern]) -> bool {
             }
         }
         sequences.values().any(|v| *v >= 2)
-            && pattern
-                .all_melds()
-                .all(|m| matches!(m, MeldKind::Sequence(_)))
     })
 }
 

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -84,6 +84,19 @@ mod tests {
     }
 
     #[test]
+    fn detect_ipeiko_with_triplet() {
+        let tiles = vec![
+            OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, // double 123m
+            FiveP, FiveP, FiveP, // 555p
+            SevenS, EightS, NineS, // 789s
+            OneS, OneS, // pair
+        ];
+
+        let result = judge_yaku(&tiles, &[], WinContext::default());
+        assert!(result.contains(&YakuId::Ipeiko));
+    }
+
+    #[test]
     fn detect_ryanpeiko() {
         let tiles = vec![
             OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, // double 123m


### PR DESCRIPTION
Fixes `has_ipeiko` so that it no longer requires all melds to be sequences, enabling it to correctly detect Ipeiko in hands that include triplets or quads. Added a test case `detect_ipeiko_with_triplet` to verify this behavior.

---
*PR created automatically by Jules for task [5490790132094648169](https://jules.google.com/task/5490790132094648169) started by @applyuser160*