### PR TITLE
Fix turn management when calling a meld

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,8 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -72,6 +74,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -109,6 +113,8 @@ jobs:
             target: x64
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -148,6 +154,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -179,6 +187,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -39,6 +41,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/src/mahjong/river.rs
+++ b/src/mahjong/river.rs
@@ -17,4 +17,8 @@ impl River {
     pub fn push(&mut self, tile: TileName) {
         self.tiles.push(tile);
     }
+
+    pub fn pop(&mut self) -> Option<TileName> {
+        self.tiles.pop()
+    }
 }

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -20,7 +20,7 @@ impl Round {
             wall,
             hands: [Hand::new(), Hand::new(), Hand::new(), Hand::new()],
             rivers: [River::new(), River::new(), River::new(), River::new()],
-            turn: 0,
+            turn: 1,
         };
 
         round.deal();

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -1,4 +1,4 @@
-use crate::hand::Hand;
+use crate::hand::{Hand, Meld};
 use crate::river::River;
 use crate::tile::TileName;
 use crate::wall::Wall;
@@ -39,6 +39,10 @@ impl Round {
         &self.rivers[index]
     }
 
+    pub fn turn(&self) -> usize {
+        self.turn
+    }
+
     pub fn play_turn(&mut self, discard_index: usize) -> Option<TileName> {
         let drawn = self.wall.draw()?;
         let hand = &mut self.hands[self.turn];
@@ -47,6 +51,53 @@ impl Round {
         self.rivers[self.turn].push(discarded);
         self.turn = (self.turn + 1) % PLAYER_NUMBER;
         Some(discarded)
+    }
+
+    pub fn play_meld(
+        &mut self,
+        player_index: usize,
+        meld: Meld,
+        discard_index: usize,
+    ) -> Result<TileName, &'static str> {
+        let previous_player = (self.turn + PLAYER_NUMBER - 1) % PLAYER_NUMBER;
+
+        let called_tile = match meld {
+            Meld::Chii { called, .. } => called,
+            Meld::Pon(called) => called,
+            Meld::Kan(called) => called,
+        };
+
+        // Determine the last discarded tile
+        let last_discard = self.rivers[previous_player].tiles().last().copied().ok_or("No tile in river to call")?;
+
+        if last_discard != called_tile {
+            return Err("Called tile does not match the last discarded tile");
+        }
+
+        // Apply meld to hand (this will fail if hand doesn't have the consumed tiles)
+        self.hands[player_index].call_meld(meld)?;
+
+        // Remove the tile from the previous player's river
+        self.rivers[previous_player].pop();
+
+        let hand = &mut self.hands[player_index];
+
+        // For Kan, we draw a replacement tile.
+        if let Meld::Kan(_) = meld {
+            if let Some(drawn) = self.wall.draw() {
+                hand.push(drawn);
+            } else {
+                return Err("Wall is empty, cannot draw replacement tile for Kan");
+            }
+        }
+
+        let discarded = hand.discard(discard_index);
+        self.rivers[player_index].push(discarded);
+
+        // Update turn: the next turn belongs to the player after the one who called the meld
+        self.turn = (player_index + 1) % PLAYER_NUMBER;
+
+        Ok(discarded)
     }
 
     fn deal(&mut self) {

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -68,7 +68,11 @@ impl Round {
         };
 
         // Determine the last discarded tile
-        let last_discard = self.rivers[previous_player].tiles().last().copied().ok_or("No tile in river to call")?;
+        let last_discard = self.rivers[previous_player]
+            .tiles()
+            .last()
+            .copied()
+            .ok_or("No tile in river to call")?;
 
         if last_discard != called_tile {
             return Err("Called tile does not match the last discarded tile");

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -4,9 +4,59 @@ mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
 
+    use mahjong::hand::Meld;
     use mahjong::round::{Round, PLAYER_NUMBER};
     use mahjong::tile::{TileName, TILE_WALL_CAPACITY};
     use mahjong::wall::Wall;
+
+    #[test]
+    fn test_play_meld_turn_update() {
+        // Find a seed where Player 2 can pon Player 0's discard.
+        let mut found_seed = None;
+        for seed in 0..1000 {
+            let mut w = Wall::new();
+            w.shuffle(&mut StdRng::seed_from_u64(seed));
+            let mut r = Round::new(w);
+
+            // P0 draws and discards the first tile (index 0)
+            let discarded = r.play_turn(0).unwrap();
+
+            // Does P2 have at least two of `discarded`?
+            let p2_hand = r.hand(2);
+            let count = p2_hand.iter().filter(|&&t| t == discarded).count();
+            if count >= 2 {
+                found_seed = Some((seed, discarded));
+                break;
+            }
+        }
+
+        let (seed, discarded) = found_seed.unwrap();
+
+        let mut wall = Wall::new();
+        wall.shuffle(&mut StdRng::seed_from_u64(seed));
+        let mut round = Round::new(wall);
+
+        // P0's turn
+        let actual_discard = round.play_turn(0).unwrap();
+        assert_eq!(actual_discard, discarded);
+        assert_eq!(round.turn(), 1);
+
+        // P2 calls Pon!
+        // Since P2 has 2 copies, they can call Pon. We discard index 0 from P2's hand after Pon.
+        let meld = Meld::Pon(discarded);
+
+        let p2_discard = round.play_meld(2, meld, 0).unwrap();
+
+        // Now turn should be 3 (P2's turn is over, next is P3)
+        assert_eq!(round.turn(), 3);
+
+        // P0's river should be missing the discarded tile (it was popped)
+        assert_eq!(round.river(0).tiles().len(), 0);
+
+        // P2's river should have the discarded tile
+        assert_eq!(round.river(2).tiles().len(), 1);
+        assert_eq!(round.river(2).tiles()[0], p2_discard);
+    }
 
     #[test]
     fn test_river_discards() {

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -18,11 +18,12 @@ mod tests {
             w.shuffle(&mut StdRng::seed_from_u64(seed));
             let mut r = Round::new(w);
 
-            // P0 draws and discards the first tile (index 0)
+            // turn is 1, so P1 plays first! Wait, the prompt says "turnの初期値は1であるべき" (initial value of turn should be 1).
+            // P1 draws and discards the first tile (index 0)
             let discarded = r.play_turn(0).unwrap();
 
-            // Does P2 have at least two of `discarded`?
-            let p2_hand = r.hand(2);
+            // Does P3 have at least two of `discarded`?
+            let p2_hand = r.hand(3);
             let count = p2_hand.iter().filter(|&&t| t == discarded).count();
             if count >= 2 {
                 found_seed = Some((seed, discarded));
@@ -36,26 +37,26 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        // P0's turn
+        // P1's turn
         let actual_discard = round.play_turn(0).unwrap();
         assert_eq!(actual_discard, discarded);
-        assert_eq!(round.turn(), 1);
+        assert_eq!(round.turn(), 2);
 
-        // P2 calls Pon!
-        // Since P2 has 2 copies, they can call Pon. We discard index 0 from P2's hand after Pon.
+        // P3 calls Pon!
+        // Since P3 has 2 copies, they can call Pon. We discard index 0 from P3's hand after Pon.
         let meld = Meld::Pon(discarded);
 
-        let p2_discard = round.play_meld(2, meld, 0).unwrap();
+        let p2_discard = round.play_meld(3, meld, 0).unwrap();
 
-        // Now turn should be 3 (P2's turn is over, next is P3)
-        assert_eq!(round.turn(), 3);
+        // Now turn should be 0 (P3's turn is over, next is P0)
+        assert_eq!(round.turn(), 0);
 
-        // P0's river should be missing the discarded tile (it was popped)
-        assert_eq!(round.river(0).tiles().len(), 0);
+        // P1's river should be missing the discarded tile (it was popped)
+        assert_eq!(round.river(1).tiles().len(), 0);
 
-        // P2's river should have the discarded tile
-        assert_eq!(round.river(2).tiles().len(), 1);
-        assert_eq!(round.river(2).tiles()[0], p2_discard);
+        // P3's river should have the discarded tile
+        assert_eq!(round.river(3).tiles().len(), 1);
+        assert_eq!(round.river(3).tiles()[0], p2_discard);
     }
 
     #[test]
@@ -64,12 +65,12 @@ mod tests {
         let mut round = Round::new(wall);
 
         let discarded = round.play_turn(0).unwrap();
-        assert_eq!(round.river(0).tiles().len(), 1);
-        assert_eq!(round.river(0).tiles()[0], discarded);
+        assert_eq!(round.river(1).tiles().len(), 1);
+        assert_eq!(round.river(1).tiles()[0], discarded);
 
         let discarded2 = round.play_turn(0).unwrap();
-        assert_eq!(round.river(1).tiles().len(), 1);
-        assert_eq!(round.river(1).tiles()[0], discarded2);
+        assert_eq!(round.river(2).tiles().len(), 1);
+        assert_eq!(round.river(2).tiles()[0], discarded2);
     }
 
     #[test]


### PR DESCRIPTION
Added dedicated meld mechanics that updates turns correctly and pops from the previous discarder's river.

---
*PR created automatically by Jules for task [12116373912115905928](https://jules.google.com/task/12116373912115905928) started by @applyuser160*