### PR TITLE
Fix missing round wind check in Yakuhai evaluation

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -451,7 +451,7 @@ pub fn judge_yaku(
     }
 
     if let Some(p) = patterns.first() {
-        if contains_yakuhai(&counts, ctx.seat_wind) {
+        if contains_yakuhai(&counts, ctx.seat_wind, ctx.round_wind) {
             if counts[TileName::White as usize] >= 3 {
                 result.insert(YakuId::YakuhaiHaku);
             }
@@ -785,11 +785,16 @@ fn detect_pinfu(patterns: &[HandPattern], ctx: &WinContext) -> Option<bool> {
     Some(false)
 }
 
-fn contains_yakuhai(counts: &[usize; 35], seat_wind: Option<TileName>) -> bool {
+fn contains_yakuhai(
+    counts: &[usize; 35],
+    seat_wind: Option<TileName>,
+    round_wind: Option<TileName>,
+) -> bool {
     counts[TileName::White as usize] >= 3
         || counts[TileName::Green as usize] >= 3
         || counts[TileName::Red as usize] >= 3
         || seat_wind.map(|w| counts[w as usize] >= 3).unwrap_or(false)
+        || round_wind.map(|w| counts[w as usize] >= 3).unwrap_or(false)
 }
 
 fn is_value_pair(tile: TileName, ctx: &WinContext) -> bool {

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -116,6 +116,27 @@ mod tests {
     }
 
     #[test]
+    fn detect_yakuhai_with_round_wind_only() {
+        let tiles = vec![
+            East, East, East, // round wind triplet
+            OneM, TwoM, ThreeM, // 123m
+            FourM, FiveM, SixM, // 456m
+            FourP, FiveP, SixP, // 456p
+            NineS, NineS, // pair
+        ];
+
+        let ctx = WinContext {
+            seat_wind: Some(South), // seat wind is South
+            round_wind: Some(East), // round wind is East
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &[], ctx);
+        // It should contain Bakaze (round wind), but not Jikaze (seat wind)
+        assert!(result.contains(&YakuId::YakuhaiBakaze));
+        assert!(!result.contains(&YakuId::YakuhaiJikaze));
+    }
+
+    #[test]
     fn detect_honitsu() {
         let tiles = vec![
             OneM, TwoM, ThreeM, // 123m


### PR DESCRIPTION
- Updated `contains_yakuhai` function signature to accept `round_wind`.
- Modified `contains_yakuhai` to check if a hand has a triplet of the round wind, allowing it to correctly identify the Bakaze yaku.
- Updated the caller inside `evaluate_yaku` to pass `ctx.round_wind`.
- Added a test case `detect_yakuhai_with_round_wind_only` in `tests/test_yaku.rs` to verify the bug fix.

---
*PR created automatically by Jules for task [6549869282356659590](https://jules.google.com/task/6549869282356659590) started by @applyuser160*