### PR TITLE
Fix Yaku combinations for Chitoitsu by moving count-based evaluations

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -493,47 +493,48 @@ pub fn judge_yaku(
         if has_sanshoku_doukou(&patterns) {
             result.insert(YakuId::SanshokuDoukou);
         }
-        if is_honitsu(&counts) {
-            result.insert(YakuId::Honitsu);
-        }
         if is_junchan(&patterns) {
             result.insert(YakuId::Junchan);
-        }
-        if is_chinitsu(&counts) {
-            result.insert(YakuId::Chinitsu);
-        }
-        if is_honroutou(&patterns) {
-            result.insert(YakuId::Honroutou);
-        }
-        if is_chinroutou(&patterns) {
-            result.insert(YakuId::Chinroutou);
         }
         if ctx.kan_count >= 3 {
             result.insert(YakuId::Sankantsu);
         }
-        if is_daisangen(&counts) {
-            result.insert(YakuId::Daisangen);
-        }
-        if let Some((small, big)) = detect_suushi(&counts) {
-            if big {
-                result.insert(YakuId::Daisuushi);
-            }
-            if small {
-                result.insert(YakuId::Shousuushi);
-            }
-        }
-        if is_tsuuiisou(&counts) {
-            result.insert(YakuId::Tsuuiisou);
-        }
-        if is_ryuuiisou(&counts) {
-            result.insert(YakuId::Ryuuiisou);
-        }
         if is_suuankou(&patterns, ctx.is_closed, &ctx) {
             result.insert(YakuId::Suuankou);
         }
-        if is_chuuren_poutou(&counts, tiles.len()) {
-            result.insert(YakuId::ChuurenPoutou);
+    }
+
+    if is_honitsu(&counts) {
+        result.insert(YakuId::Honitsu);
+    }
+    if is_chinitsu(&counts) {
+        result.insert(YakuId::Chinitsu);
+    }
+    if is_honroutou(&counts) {
+        result.insert(YakuId::Honroutou);
+    }
+    if is_chinroutou(&counts) {
+        result.insert(YakuId::Chinroutou);
+    }
+    if is_daisangen(&counts) {
+        result.insert(YakuId::Daisangen);
+    }
+    if let Some((small, big)) = detect_suushi(&counts) {
+        if big {
+            result.insert(YakuId::Daisuushi);
         }
+        if small {
+            result.insert(YakuId::Shousuushi);
+        }
+    }
+    if is_tsuuiisou(&counts) {
+        result.insert(YakuId::Tsuuiisou);
+    }
+    if is_ryuuiisou(&counts) {
+        result.insert(YakuId::Ryuuiisou);
+    }
+    if is_chuuren_poutou(&counts, tiles.len()) {
+        result.insert(YakuId::ChuurenPoutou);
     }
 
     result
@@ -993,28 +994,20 @@ fn is_junchan(patterns: &[HandPattern]) -> bool {
     })
 }
 
-fn is_honroutou(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        if !is_terminal_or_honor(pattern.pair) {
-            return false;
-        }
-        pattern.all_melds().all(|m| match m {
-            MeldKind::Triplet(tile) | MeldKind::Quad(tile) => is_terminal_or_honor(*tile),
-            MeldKind::Sequence(_) => false,
-        })
-    })
+fn is_honroutou(counts: &[usize; 35]) -> bool {
+    counts
+        .iter()
+        .enumerate()
+        .skip(1)
+        .all(|(i, c)| *c == 0 || is_terminal_or_honor(TileName::from_usize(i)))
 }
 
-fn is_chinroutou(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        if !is_terminal(pattern.pair) {
-            return false;
-        }
-        pattern.all_melds().all(|m| match m {
-            MeldKind::Triplet(tile) | MeldKind::Quad(tile) => is_terminal(*tile),
-            MeldKind::Sequence(_) => false,
-        })
-    })
+fn is_chinroutou(counts: &[usize; 35]) -> bool {
+    counts
+        .iter()
+        .enumerate()
+        .skip(1)
+        .all(|(i, c)| *c == 0 || is_terminal(TileName::from_usize(i)))
 }
 
 fn detect_suushi(counts: &[usize; 35]) -> Option<(bool, bool)> {

--- a/tests/test_chitoitsu_complex.rs
+++ b/tests/test_chitoitsu_complex.rs
@@ -1,0 +1,75 @@
+use mahjong::tile::TileName::*;
+use mahjong::yaku::{judge_yaku, WinContext, YakuId};
+
+#[test]
+fn test_chitoitsu_honitsu() {
+    let tiles = vec![
+        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, FourM, FourM, FiveM, FiveM, SixM, SixM, Red, Red,
+    ];
+
+    let result = judge_yaku(
+        &tiles,
+        &[],
+        WinContext {
+            is_closed: true,
+            ..Default::default()
+        },
+    );
+    assert!(result.contains(&YakuId::Chitoitsu));
+    assert!(result.contains(&YakuId::Honitsu));
+}
+
+#[test]
+fn test_chitoitsu_chinitsu() {
+    let tiles = vec![
+        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, FourM, FourM, FiveM, FiveM, SixM, SixM, SevenM,
+        SevenM,
+    ];
+
+    let result = judge_yaku(
+        &tiles,
+        &[],
+        WinContext {
+            is_closed: true,
+            ..Default::default()
+        },
+    );
+    assert!(result.contains(&YakuId::Chitoitsu));
+    assert!(result.contains(&YakuId::Chinitsu));
+}
+
+#[test]
+fn test_chitoitsu_honroutou() {
+    let tiles = vec![
+        OneM, OneM, NineM, NineM, OneP, OneP, NineP, NineP, OneS, OneS, NineS, NineS, East, East,
+    ];
+
+    let result = judge_yaku(
+        &tiles,
+        &[],
+        WinContext {
+            is_closed: true,
+            ..Default::default()
+        },
+    );
+    assert!(result.contains(&YakuId::Chitoitsu));
+    assert!(result.contains(&YakuId::Honroutou));
+}
+
+#[test]
+fn test_chitoitsu_tsuuiisou() {
+    let tiles = vec![
+        East, East, South, South, West, West, North, North, White, White, Green, Green, Red, Red,
+    ];
+
+    let result = judge_yaku(
+        &tiles,
+        &[],
+        WinContext {
+            is_closed: true,
+            ..Default::default()
+        },
+    );
+    assert!(result.contains(&YakuId::Chitoitsu));
+    assert!(result.contains(&YakuId::Tsuuiisou));
+}


### PR DESCRIPTION
The `judge_yaku` function currently skips evaluating several yaku that apply to the whole hand (e.g., Honitsu, Chinitsu, Honroutou) if the hand is a Chitoitsu (Seven Pairs), because it checks for these yaku inside a block that expects a standard 4-meld/1-pair shape.

This PR refactors the logic:
1. It updates `is_honroutou` and `is_chinroutou` to use raw tile counts instead of standard meld patterns.
2. It moves the evaluation of purely compositional yaku outside the `if let Some(p) = patterns.first()` block in `judge_yaku`, ensuring they evaluate successfully for Chitoitsu. 

Tested combinations such as Chitoitsu + Honitsu, Chitoitsu + Chinitsu, Chitoitsu + Honroutou, and Chitoitsu + Tsuuiisou. Tests and clippy lints pass.

---
*PR created automatically by Jules for task [12132563908890000191](https://jules.google.com/task/12132563908890000191) started by @applyuser160*