### PR TITLE
Support Daiminkan, Ankan, and Kakan melds

### DIFF
--- a/src/mahjong/hand.rs
+++ b/src/mahjong/hand.rs
@@ -7,7 +7,9 @@ pub enum Meld {
         consumed: [TileName; 2],
     },
     Pon(TileName),
-    Kan(TileName),
+    Daiminkan(TileName),
+    Ankan(TileName),
+    Kakan(TileName),
 }
 
 #[derive(Clone, Debug)]
@@ -70,7 +72,15 @@ impl Hand {
                 consumed.to_vec()
             }
             Meld::Pon(tile) => vec![tile, tile],
-            Meld::Kan(tile) => vec![tile, tile, tile],
+            Meld::Daiminkan(tile) => vec![tile, tile, tile],
+            Meld::Ankan(tile) => vec![tile, tile, tile, tile],
+            Meld::Kakan(tile) => {
+                // Must have a corresponding Pon
+                if !self.open_melds.contains(&Meld::Pon(tile)) {
+                    return Err("Cannot call Kakan without an existing Pon");
+                }
+                vec![tile]
+            }
         };
 
         // Verify that we have the consumed tiles, accounting for duplicates
@@ -90,7 +100,14 @@ impl Hand {
             }
         }
 
-        self.open_melds.push(meld);
+        if let Meld::Kakan(tile) = meld {
+            if let Some(pos) = self.open_melds.iter().position(|&m| m == Meld::Pon(tile)) {
+                self.open_melds[pos] = meld;
+            }
+        } else {
+            self.open_melds.push(meld);
+        }
+
         Ok(())
     }
 }

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -64,7 +64,9 @@ impl Round {
         let called_tile = match meld {
             Meld::Chii { called, .. } => called,
             Meld::Pon(called) => called,
-            Meld::Kan(called) => called,
+            Meld::Daiminkan(called) => called,
+            Meld::Ankan(called) => called,
+            Meld::Kakan(called) => called,
         };
 
         // Determine the last discarded tile
@@ -87,7 +89,7 @@ impl Round {
         let hand = &mut self.hands[player_index];
 
         // For Kan, we draw a replacement tile.
-        if let Meld::Kan(_) = meld {
+        if let Meld::Daiminkan(_) | Meld::Ankan(_) = meld {
             if let Some(drawn) = self.wall.draw() {
                 hand.push(drawn);
             } else {

--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -385,7 +385,17 @@ pub fn judge_yaku(
         return result;
     }
 
-    if !open_melds_input.is_empty() {
+    let mut has_open_meld = false;
+    for meld in open_melds_input {
+        match meld {
+            crate::hand::Meld::Chii { .. } | crate::hand::Meld::Pon(_) | crate::hand::Meld::Daiminkan(_) | crate::hand::Meld::Kakan(_) => {
+                has_open_meld = true;
+            }
+            crate::hand::Meld::Ankan(_) => {}
+        }
+    }
+
+    if has_open_meld {
         ctx.is_closed = false;
     }
 
@@ -398,15 +408,30 @@ pub fn judge_yaku(
     }
 
     let mut open_melds = Vec::new();
+    let mut closed_melds = Vec::new();
+    let mut kan_count = 0;
+
     for meld in open_melds_input {
         match meld {
             crate::hand::Meld::Chii { called, .. } => open_melds.push(MeldKind::Sequence(*called)),
             crate::hand::Meld::Pon(tile) => open_melds.push(MeldKind::Triplet(*tile)),
-            crate::hand::Meld::Kan(tile) => open_melds.push(MeldKind::Quad(*tile)),
+            crate::hand::Meld::Daiminkan(tile) | crate::hand::Meld::Kakan(tile) => {
+                open_melds.push(MeldKind::Quad(*tile));
+                kan_count += 1;
+            }
+            crate::hand::Meld::Ankan(tile) => {
+                closed_melds.push(MeldKind::Quad(*tile));
+                kan_count += 1;
+            }
         }
     }
 
-    let patterns = generate_patterns(&counts, &open_melds);
+    // Use derived kan count for Sankantsu if it exceeds the context provided one
+    if kan_count > ctx.kan_count {
+        ctx.kan_count = kan_count;
+    }
+
+    let patterns = generate_patterns(&counts, &open_melds, &closed_melds);
 
     if ctx.riichi && ctx.is_closed {
         result.insert(YakuId::Riichi);
@@ -628,7 +653,7 @@ fn is_simple(tile: TileName) -> bool {
     )
 }
 
-fn generate_patterns(counts: &[usize; 35], open_melds: &[MeldKind]) -> Vec<HandPattern> {
+fn generate_patterns(counts: &[usize; 35], open_melds: &[MeldKind], closed_melds: &[MeldKind]) -> Vec<HandPattern> {
     let mut patterns = Vec::new();
 
     for i in 1..counts.len() {
@@ -638,7 +663,7 @@ fn generate_patterns(counts: &[usize; 35], open_melds: &[MeldKind]) -> Vec<HandP
         let mut working = *counts;
         working[i] -= 2;
         let pair = TileName::from_usize(i);
-        let mut melds = Vec::new();
+        let mut melds = closed_melds.to_vec();
         search_melds(&mut working, &mut melds, &mut patterns, pair, open_melds);
     }
 

--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -388,7 +388,10 @@ pub fn judge_yaku(
     let mut has_open_meld = false;
     for meld in open_melds_input {
         match meld {
-            crate::hand::Meld::Chii { .. } | crate::hand::Meld::Pon(_) | crate::hand::Meld::Daiminkan(_) | crate::hand::Meld::Kakan(_) => {
+            crate::hand::Meld::Chii { .. }
+            | crate::hand::Meld::Pon(_)
+            | crate::hand::Meld::Daiminkan(_)
+            | crate::hand::Meld::Kakan(_) => {
                 has_open_meld = true;
             }
             crate::hand::Meld::Ankan(_) => {}
@@ -654,7 +657,11 @@ fn is_simple(tile: TileName) -> bool {
     )
 }
 
-fn generate_patterns(counts: &[usize; 35], open_melds: &[MeldKind], closed_melds: &[MeldKind]) -> Vec<HandPattern> {
+fn generate_patterns(
+    counts: &[usize; 35],
+    open_melds: &[MeldKind],
+    closed_melds: &[MeldKind],
+) -> Vec<HandPattern> {
     let mut patterns = Vec::new();
 
     for i in 1..counts.len() {

--- a/tests/test_hand.rs
+++ b/tests/test_hand.rs
@@ -92,4 +92,64 @@ mod tests {
         let result = hand.call_meld(Meld::Pon(Red));
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_call_meld_daiminkan() {
+        let mut hand = Hand::new();
+        hand.push(Red);
+        hand.push(Red);
+        hand.push(Red);
+
+        assert!(hand.call_meld(Meld::Daiminkan(Red)).is_ok());
+        assert_eq!(hand.open_melds.len(), 1);
+        assert_eq!(hand.open_melds[0], Meld::Daiminkan(Red));
+        assert_eq!(hand.tiles().len(), 0);
+    }
+
+    #[test]
+    fn test_call_meld_ankan() {
+        let mut hand = Hand::new();
+        hand.push(Red);
+        hand.push(Red);
+        hand.push(Red);
+        hand.push(Red);
+
+        assert!(hand.call_meld(Meld::Ankan(Red)).is_ok());
+        assert_eq!(hand.open_melds.len(), 1);
+        assert_eq!(hand.open_melds[0], Meld::Ankan(Red));
+        assert_eq!(hand.tiles().len(), 0);
+    }
+
+    #[test]
+    fn test_call_meld_kakan() {
+        let mut hand = Hand::new();
+        hand.push(Red);
+        hand.push(Red); // Hand has a pair (2 tiles)
+
+        // Declare Pon (consumes the 2 tiles in hand, forming an open triplet)
+        assert!(hand.call_meld(Meld::Pon(Red)).is_ok());
+        assert_eq!(hand.tiles().len(), 0);
+
+        // Draw the 4th Red
+        hand.push(Red);
+        assert_eq!(hand.tiles().len(), 1);
+
+        // Declare Kakan (consumes 1 tile in hand, promoting the Pon)
+        assert!(hand.call_meld(Meld::Kakan(Red)).is_ok());
+
+        assert_eq!(hand.open_melds.len(), 1);
+        assert_eq!(hand.open_melds[0], Meld::Kakan(Red));
+        assert_eq!(hand.tiles().len(), 0);
+    }
+
+    #[test]
+    fn test_call_meld_kakan_without_pon() {
+        let mut hand = Hand::new();
+        hand.push(Red);
+
+        // Try to Kakan without a prior Pon
+        let result = hand.call_meld(Meld::Kakan(Red));
+        assert!(result.is_err());
+        assert_eq!(hand.open_melds.len(), 0);
+    }
 }

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -392,9 +392,9 @@ mod tests {
 
 #[cfg(test)]
 mod tests_kan {
+    use mahjong::hand::Meld;
     use mahjong::tile::TileName::*;
     use mahjong::yaku::{judge_yaku, WinContext, YakuId};
-    use mahjong::hand::Meld;
 
     #[test]
     fn detect_sanankou_passes_with_ankan() {

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -274,3 +274,52 @@ mod tests {
         assert!(result.contains(&YakuId::Toitoi));
     }
 }
+
+#[cfg(test)]
+mod tests_kan {
+    use mahjong::tile::TileName::*;
+    use mahjong::yaku::{judge_yaku, WinContext, YakuId};
+    use mahjong::hand::Meld;
+
+    #[test]
+    fn detect_sanankou_passes_with_ankan() {
+        let tiles = vec![
+            OneM, OneM, OneM, // 111m
+            TwoM, TwoM, TwoM, // 222m
+            FourM, FiveM, SixM, // 456m
+            White, White, // pair
+        ];
+
+        let open_melds = vec![Meld::Ankan(ThreeM)];
+
+        let ctx = WinContext {
+            is_tsumo: true,
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &open_melds, ctx);
+        // Ankan is a closed meld, so we have 3 closed triplets/quads (111m, 222m, 3333m)
+        assert!(result.contains(&YakuId::Sanankou));
+    }
+
+    #[test]
+    fn detect_sankantsu() {
+        let tiles = vec![
+            OneM, TwoM, ThreeM, // 123m
+            White, White, // pair
+        ];
+
+        // 3 Kans -> Sankantsu
+        let open_melds = vec![
+            mahjong::hand::Meld::Ankan(ThreeP),
+            mahjong::hand::Meld::Daiminkan(FourP),
+            mahjong::hand::Meld::Kakan(FiveP),
+        ];
+
+        let ctx = WinContext {
+            is_tsumo: true,
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &open_melds, ctx);
+        assert!(result.contains(&YakuId::Sankantsu));
+    }
+}


### PR DESCRIPTION
Replaced the generic `Meld::Kan` variant with `Daiminkan`, `Ankan`, and `Kakan` to better reflect actual Mahjong rules. 

`hand.rs` was updated to accurately track the tile consumption for each meld type (Daiminkan=3, Ankan=4, Kakan=1) and ensure that `Kakan` correctly verifies and promotes a pre-existing `Pon`.
`yaku.rs` was updated to treat `Ankan` strictly as a closed meld that does not open the hand, and automatically derive `kan_count` to ensure `Sankantsu` and related Kan yakus work seamlessly.

Tests have been added to verify that tile counts and game state remain accurate after each meld type is called.

---
*PR created automatically by Jules for task [17013787725534032290](https://jules.google.com/task/17013787725534032290) started by @applyuser160*