### PR TITLE
Fix implicit Quad creation from 4-of-a-kind in hand

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -713,14 +713,6 @@ fn search_melds(
         counts[i] += 3;
     }
 
-    if counts[i] >= 4 {
-        counts[i] -= 4;
-        melds.push(MeldKind::Quad(tile));
-        search_melds(counts, melds, patterns, pair, open_melds);
-        melds.pop();
-        counts[i] += 4;
-    }
-
     if let Some((suit, rank)) = is_number_tile(tile) {
         if rank <= 7 {
             let next1 = i + 1;

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -194,6 +194,26 @@ mod tests {
     }
 
     #[test]
+    fn detect_sanankou_with_undeclared_quad() {
+        let tiles = vec![
+            TwoM, TwoM, TwoM, TwoM, // 2222m (used as 222m triplet + 2m for sequence)
+            ThreeM, FourM, // 34m (completed as 234m sequence)
+            SixP, SixP, SixP, // 666p
+            NineS, NineS, NineS, // 999s
+            East, East, // pair
+        ];
+
+        let ctx = WinContext {
+            is_tsumo: true,
+            is_closed: true,
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &[], ctx);
+        // This hand is Sanankou (222m, 666p, 999s are closed triplets).
+        assert!(result.contains(&YakuId::Sanankou));
+    }
+
+    #[test]
     fn detect_sanankou_tsumo() {
         let tiles = vec![
             OneM, OneM, OneM, // 111m


### PR DESCRIPTION
Fix implicit Quad creation from 4-of-a-kind in hand

In mahjong, having 4 of the same tile in a hand does not automatically
constitute a Kan (Quad). It should only be counted as a Quad if a Kan
was explicitly declared. Without a Kan, these 4 tiles can only be used
in groups of triplets, pairs, or sequences. The logic implicitly creating
a `MeldKind::Quad` from 4 matching tiles in `search_melds` was removed
to enforce this behavior and correctly support Yaku evaluations on hands
containing 4 matching tiles.

Also added a test for Sanankou correctly matching a hand with 4 matching
tiles used as a triplet and a sequence.

---
*PR created automatically by Jules for task [17600521653150217378](https://jules.google.com/task/17600521653150217378) started by @applyuser160*