### PR TITLE
Fix Ankan and Kakan play_meld behavior to bypass last discard check

### DIFF
--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -61,35 +61,37 @@ impl Round {
     ) -> Result<TileName, &'static str> {
         let previous_player = (self.turn + PLAYER_NUMBER - 1) % PLAYER_NUMBER;
 
-        let called_tile = match meld {
-            Meld::Chii { called, .. } => called,
-            Meld::Pon(called) => called,
-            Meld::Daiminkan(called) => called,
-            Meld::Ankan(called) => called,
-            Meld::Kakan(called) => called,
-        };
-
-        // Determine the last discarded tile
-        let last_discard = self.rivers[previous_player]
-            .tiles()
-            .last()
-            .copied()
-            .ok_or("No tile in river to call")?;
-
-        if last_discard != called_tile {
-            return Err("Called tile does not match the last discarded tile");
-        }
-
         // Apply meld to hand (this will fail if hand doesn't have the consumed tiles)
-        self.hands[player_index].call_meld(meld)?;
+        // Check condition before modifying the state
+        match meld {
+            Meld::Chii { called, .. } | Meld::Pon(called) | Meld::Daiminkan(called) => {
+                // Determine the last discarded tile
+                let last_discard = self.rivers[previous_player]
+                    .tiles()
+                    .last()
+                    .copied()
+                    .ok_or("No tile in river to call")?;
 
-        // Remove the tile from the previous player's river
-        self.rivers[previous_player].pop();
+                if last_discard != called {
+                    return Err("Called tile does not match the last discarded tile");
+                }
+
+                self.hands[player_index].call_meld(meld)?;
+
+                // Remove the tile from the previous player's river
+                self.rivers[previous_player].pop();
+            }
+            Meld::Ankan(_) | Meld::Kakan(_) => {
+                // For Ankan and Kakan, we do not depend on the previous player's discard.
+                // We just call the meld directly.
+                self.hands[player_index].call_meld(meld)?;
+            }
+        }
 
         let hand = &mut self.hands[player_index];
 
         // For Kan, we draw a replacement tile.
-        if let Meld::Daiminkan(_) | Meld::Ankan(_) = meld {
+        if let Meld::Daiminkan(_) | Meld::Ankan(_) | Meld::Kakan(_) = meld {
             if let Some(drawn) = self.wall.draw() {
                 hand.push(drawn);
             } else {

--- a/tests/test_hand.rs
+++ b/tests/test_hand.rs
@@ -103,6 +103,7 @@ mod tests {
         assert!(hand.discard(100).is_err());
     }
 
+    #[test]
     fn test_call_meld_daiminkan() {
         let mut hand = Hand::new();
         hand.push(Red);

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -88,7 +88,9 @@ mod tests {
             let r = Round::new(w);
             let p1_hand = r.hand(1);
             let mut counts = [0; 40];
-            for &t in p1_hand { counts[t as usize] += 1; }
+            for &t in p1_hand {
+                counts[t as usize] += 1;
+            }
             if counts.iter().any(|&c| c >= 4) {
                 let tile_idx = counts.iter().position(|&c| c >= 4).unwrap();
                 found_ankan = Some((seed, TileName::from_usize(tile_idx)));
@@ -110,9 +112,21 @@ mod tests {
 
         assert!(res.is_ok(), "Ankan should succeed");
 
-        assert_eq!(round.river(0).tiles().len(), r0_len_before, "River should not be popped");
-        assert_eq!(round.river(2).tiles().len(), r2_len_before, "River should not be popped");
-        assert_eq!(round.river(3).tiles().len(), r3_len_before, "River should not be popped");
+        assert_eq!(
+            round.river(0).tiles().len(),
+            r0_len_before,
+            "River should not be popped"
+        );
+        assert_eq!(
+            round.river(2).tiles().len(),
+            r2_len_before,
+            "River should not be popped"
+        );
+        assert_eq!(
+            round.river(3).tiles().len(),
+            r3_len_before,
+            "River should not be popped"
+        );
     }
 
     #[test]
@@ -126,7 +140,9 @@ mod tests {
             let p0_hand = r.hand(0);
 
             let mut p1_counts = [0; 40];
-            for &t in p1_hand { p1_counts[t as usize] += 1; }
+            for &t in p1_hand {
+                p1_counts[t as usize] += 1;
+            }
 
             if p1_counts.iter().any(|&c| c >= 3) {
                 let tile_idx = p1_counts.iter().position(|&c| c >= 3).unwrap();
@@ -169,8 +185,20 @@ mod tests {
         let res_kakan = round.play_meld(1, kakan_meld, 0);
         assert!(res_kakan.is_ok(), "Kakan should succeed");
 
-        assert_eq!(round.river(0).tiles().len(), r0_len, "River should not be popped");
-        assert_eq!(round.river(2).tiles().len(), r2_len, "River should not be popped");
-        assert_eq!(round.river(3).tiles().len(), r3_len, "River should not be popped");
+        assert_eq!(
+            round.river(0).tiles().len(),
+            r0_len,
+            "River should not be popped"
+        );
+        assert_eq!(
+            round.river(2).tiles().len(),
+            r2_len,
+            "River should not be popped"
+        );
+        assert_eq!(
+            round.river(3).tiles().len(),
+            r3_len,
+            "River should not be popped"
+        );
     }
 }

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-
 mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
@@ -11,18 +10,12 @@ mod tests {
 
     #[test]
     fn test_play_meld_turn_update() {
-        // Find a seed where Player 2 can pon Player 0's discard.
         let mut found_seed = None;
         for seed in 0..1000 {
             let mut w = Wall::new();
             w.shuffle(&mut StdRng::seed_from_u64(seed));
             let mut r = Round::new(w);
-
-            // turn is 1, so P1 plays first! Wait, the prompt says "turnの初期値は1であるべき" (initial value of turn should be 1).
-            // P1 draws and discards the first tile (index 0)
             let discarded = r.play_turn(0).unwrap();
-
-            // Does P3 have at least two of `discarded`?
             let p2_hand = r.hand(3);
             let count = p2_hand.iter().filter(|&&t| t == discarded).count();
             if count >= 2 {
@@ -32,29 +25,19 @@ mod tests {
         }
 
         let (seed, discarded) = found_seed.unwrap();
-
         let mut wall = Wall::new();
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        // P1's turn
         let actual_discard = round.play_turn(0).unwrap();
         assert_eq!(actual_discard, discarded);
         assert_eq!(round.turn(), 2);
 
-        // P3 calls Pon!
-        // Since P3 has 2 copies, they can call Pon. We discard index 0 from P3's hand after Pon.
         let meld = Meld::Pon(discarded);
-
         let p2_discard = round.play_meld(3, meld, 0).unwrap();
 
-        // Now turn should be 0 (P3's turn is over, next is P0)
         assert_eq!(round.turn(), 0);
-
-        // P1's river should be missing the discarded tile (it was popped)
         assert_eq!(round.river(1).tiles().len(), 0);
-
-        // P3's river should have the discarded tile
         assert_eq!(round.river(3).tiles().len(), 1);
         assert_eq!(round.river(3).tiles()[0], p2_discard);
     }
@@ -94,5 +77,100 @@ mod tests {
 
         let total_tiles = PLAYER_NUMBER * 13 + draws;
         assert_eq!(total_tiles, TILE_WALL_CAPACITY);
+    }
+
+    #[test]
+    fn test_play_meld_ankan() {
+        let mut found_ankan = None;
+        for seed in 0..100000 {
+            let mut w = Wall::new();
+            w.shuffle(&mut StdRng::seed_from_u64(seed));
+            let r = Round::new(w);
+            let p1_hand = r.hand(1);
+            let mut counts = [0; 40];
+            for &t in p1_hand { counts[t as usize] += 1; }
+            if counts.iter().any(|&c| c >= 4) {
+                let tile_idx = counts.iter().position(|&c| c >= 4).unwrap();
+                found_ankan = Some((seed, TileName::from_usize(tile_idx)));
+                break;
+            }
+        }
+
+        let (seed, tile) = found_ankan.unwrap();
+        let mut wall = Wall::new();
+        wall.shuffle(&mut StdRng::seed_from_u64(seed));
+        let mut round = Round::new(wall);
+
+        let r0_len_before = round.river(0).tiles().len();
+        let r2_len_before = round.river(2).tiles().len();
+        let r3_len_before = round.river(3).tiles().len();
+
+        let meld = Meld::Ankan(tile);
+        let res = round.play_meld(1, meld, 0);
+
+        assert!(res.is_ok(), "Ankan should succeed");
+
+        assert_eq!(round.river(0).tiles().len(), r0_len_before, "River should not be popped");
+        assert_eq!(round.river(2).tiles().len(), r2_len_before, "River should not be popped");
+        assert_eq!(round.river(3).tiles().len(), r3_len_before, "River should not be popped");
+    }
+
+    #[test]
+    fn test_play_meld_kakan() {
+        let mut found_kakan = None;
+        for seed in 0..100000 {
+            let mut w = Wall::new();
+            w.shuffle(&mut StdRng::seed_from_u64(seed));
+            let r = Round::new(w);
+            let p1_hand = r.hand(1);
+            let p0_hand = r.hand(0);
+
+            let mut p1_counts = [0; 40];
+            for &t in p1_hand { p1_counts[t as usize] += 1; }
+
+            if p1_counts.iter().any(|&c| c >= 3) {
+                let tile_idx = p1_counts.iter().position(|&c| c >= 3).unwrap();
+                let target_tile = TileName::from_usize(tile_idx);
+                // P0 needs the tile to discard on their turn (which is the 4th turn of the first round, index 0 might not be discarded if play_turn draws then discards)
+                // wait, play_turn(0) draws a tile THEN discards the tile at index 0 of the NEW hand.
+                // The new hand has 14 tiles. So index 0 is the first tile originally dealt.
+                if p0_hand[0] == target_tile {
+                    found_kakan = Some((seed, target_tile));
+                    break;
+                }
+            }
+        }
+
+        let (seed, tile) = found_kakan.unwrap();
+        let mut wall = Wall::new();
+        wall.shuffle(&mut StdRng::seed_from_u64(seed));
+        let mut round = Round::new(wall);
+
+        round.play_turn(0).unwrap(); // P1 plays, turn -> 2
+        round.play_turn(0).unwrap(); // P2 plays, turn -> 3
+        round.play_turn(0).unwrap(); // P3 plays, turn -> 0
+
+        let p0_discard = round.play_turn(0).unwrap();
+        assert_eq!(p0_discard, tile);
+
+        let pon_meld = Meld::Pon(tile);
+        let res = round.play_meld(1, pon_meld, 0);
+        assert!(res.is_ok());
+
+        round.play_turn(0).unwrap(); // P2 plays, turn -> 3
+        round.play_turn(0).unwrap(); // P3 plays, turn -> 0
+        round.play_turn(0).unwrap(); // P0 plays, turn -> 1
+
+        let kakan_meld = Meld::Kakan(tile);
+        let r0_len = round.river(0).tiles().len();
+        let r2_len = round.river(2).tiles().len();
+        let r3_len = round.river(3).tiles().len();
+
+        let res_kakan = round.play_meld(1, kakan_meld, 0);
+        assert!(res_kakan.is_ok(), "Kakan should succeed");
+
+        assert_eq!(round.river(0).tiles().len(), r0_len, "River should not be popped");
+        assert_eq!(round.river(2).tiles().len(), r2_len, "River should not be popped");
+        assert_eq!(round.river(3).tiles().len(), r3_len, "River should not be popped");
     }
 }


### PR DESCRIPTION
Fix Ankan and Kakan play_meld behavior to bypass last discard check

---
*PR created automatically by Jules for task [16442221999276530496](https://jules.google.com/task/16442221999276530496) started by @applyuser160*