### PR TITLE
Fix yaku evaluation ignoring open meld tiles

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -410,6 +410,22 @@ pub fn judge_yaku(
         }
     }
 
+    for meld in open_melds_input {
+        let meld_tiles = match meld {
+            crate::hand::Meld::Chii { called, consumed } => vec![*called, consumed[0], consumed[1]],
+            crate::hand::Meld::Pon(t) => vec![*t, *t, *t],
+            crate::hand::Meld::Daiminkan(t)
+            | crate::hand::Meld::Ankan(t)
+            | crate::hand::Meld::Kakan(t) => vec![*t, *t, *t, *t],
+        };
+        for tile in meld_tiles {
+            let idx = tile as usize;
+            if idx < counts.len() {
+                counts[idx] += 1;
+            }
+        }
+    }
+
     let mut open_melds = Vec::new();
     let mut closed_melds = Vec::new();
     let mut kan_count = 0;
@@ -434,7 +450,17 @@ pub fn judge_yaku(
         ctx.kan_count = kan_count;
     }
 
-    let patterns = generate_patterns(&counts, &open_melds, &closed_melds);
+    let mut closed_counts = [0usize; 35];
+    for tile in tiles.iter().copied() {
+        let idx = tile as usize;
+        if idx < closed_counts.len() {
+            closed_counts[idx] += 1;
+        }
+    }
+
+    // For pattern generation, we should only use the tiles from the closed hand
+    // (excluding open melds). Otherwise, it tries to re-parse the open meld tiles.
+    let patterns = generate_patterns(&closed_counts, &open_melds, &closed_melds);
 
     if ctx.riichi && ctx.is_closed {
         result.insert(YakuId::Riichi);

--- a/tests/test_yaku_open_melds.rs
+++ b/tests/test_yaku_open_melds.rs
@@ -1,0 +1,30 @@
+use mahjong::hand::Meld;
+use mahjong::tile::TileName;
+use mahjong::yaku::{judge_yaku, WinContext, YakuId};
+
+#[test]
+fn test_yaku_open_melds() {
+    // A hand that relies on an open meld for YakuhaiHaku
+    // Tiles: 123m 123p 123s 22s
+    let tiles = vec![
+        TileName::OneM,
+        TileName::TwoM,
+        TileName::ThreeM,
+        TileName::OneP,
+        TileName::TwoP,
+        TileName::ThreeP,
+        TileName::OneS,
+        TileName::TwoS,
+        TileName::ThreeS,
+        TileName::TwoS,
+        TileName::TwoS,
+    ];
+    // Meld: Pon of White Dragon
+    let melds = vec![Meld::Pon(TileName::White)];
+
+    let mut ctx = WinContext::default();
+    ctx.is_closed = false;
+
+    let result = judge_yaku(&tiles, &melds, ctx);
+    assert!(result.contains(&YakuId::YakuhaiHaku));
+}


### PR DESCRIPTION
The counts array inside judge_yaku only tracked tiles from the closed
hand, meaning yaku like Yakuhai, Tanyao, and Honitsu could incorrectly
fail or pass when melds were involved.

This change adds open meld tiles into the `counts` array used for global
yaku checks. It also introduces `closed_counts` exclusively for
`generate_patterns` to ensure the open melds are not re-parsed,
maintaining correctness across test cases.

---
*PR created automatically by Jules for task [3096695409584108279](https://jules.google.com/task/3096695409584108279) started by @applyuser160*