### PR TITLE
Fix bug where normal yaku are mixed with Yakuman results

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -453,6 +453,22 @@ pub fn judge_yaku(
 
     if is_kokushi(&counts) {
         result.insert(YakuId::KokushiMusou);
+
+        let has_yakuman = result.iter().any(|&id| {
+            ALL_YAKU
+                .iter()
+                .find(|y| y.id == id)
+                .is_some_and(|y| y.yakuman)
+        });
+        if has_yakuman {
+            result.retain(|&id| {
+                ALL_YAKU
+                    .iter()
+                    .find(|y| y.id == id)
+                    .is_some_and(|y| y.yakuman)
+            });
+        }
+
         return result;
     }
 
@@ -563,6 +579,21 @@ pub fn judge_yaku(
     }
     if is_chuuren_poutou(&counts, tiles.len()) {
         result.insert(YakuId::ChuurenPoutou);
+    }
+
+    let has_yakuman = result.iter().any(|&id| {
+        ALL_YAKU
+            .iter()
+            .find(|y| y.id == id)
+            .is_some_and(|y| y.yakuman)
+    });
+    if has_yakuman {
+        result.retain(|&id| {
+            ALL_YAKU
+                .iter()
+                .find(|y| y.id == id)
+                .is_some_and(|y| y.yakuman)
+        });
     }
 
     result

--- a/tests/test_chitoitsu_complex.rs
+++ b/tests/test_chitoitsu_complex.rs
@@ -70,6 +70,6 @@ fn test_chitoitsu_tsuuiisou() {
             ..Default::default()
         },
     );
-    assert!(result.contains(&YakuId::Chitoitsu));
+    assert!(!result.contains(&YakuId::Chitoitsu));
     assert!(result.contains(&YakuId::Tsuuiisou));
 }

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -57,7 +57,7 @@ mod tests {
 
         let result = judge_yaku(&tiles, &[], WinContext::default());
         assert!(result.contains(&YakuId::Daisangen));
-        assert!(result.contains(&YakuId::Toitoi));
+        assert!(!result.contains(&YakuId::Toitoi));
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
 
         let result = judge_yaku(&tiles, &[], WinContext::default());
         assert!(result.contains(&YakuId::Chinroutou));
-        assert!(result.contains(&YakuId::Honroutou));
+        assert!(!result.contains(&YakuId::Honroutou));
     }
 
     #[test]
@@ -476,5 +476,22 @@ mod tests_kan {
         };
         let result = judge_yaku(&tiles, &open_melds, ctx);
         assert!(result.contains(&YakuId::Sankantsu));
+    }
+
+    #[test]
+    fn test_yakuman_filters_normal_yaku() {
+        let tiles = vec![
+            OneM, NineM, OneP, NineP, OneS, NineS, East, South, West, North, Red, Green, White,
+            White,
+        ];
+        // Ensure that normal yaku are filtered out when Yakuman is achieved.
+        let mut ctx = WinContext::default();
+        ctx.riichi = true;
+        ctx.is_closed = true;
+
+        let result = judge_yaku(&tiles, &[], ctx);
+
+        assert!(result.contains(&YakuId::KokushiMusou));
+        assert!(!result.contains(&YakuId::Riichi));
     }
 }


### PR DESCRIPTION
In Japanese Mahjong, when a Yakuman hand is achieved, normal yaku (like Riichi, Yakuhai, etc.) are ignored. This commit addresses a bug where `judge_yaku` was previously returning both Yakuman and normal yaku together.

- Added logic to `judge_yaku` checking for any `yakuman: true` in the parsed results.
- If true, `.retain()` is called on the HashSet to filter out non-yakuman entries.
- Logic is placed both at the end of the function, and right before the early-return for `KokushiMusou` to accurately handle contextual yaku like `Riichi` or `Tenhou`.
- Fixed existing tests where normal yaku were incorrectly checked for alongside Yakumans (like Chitoitsu alongside Tsuuiisou).
- Added `test_yakuman_filters_normal_yaku` to verify this exact behavior (Kokushi Musou + Riichi).

---
*PR created automatically by Jules for task [9548464000390658545](https://jules.google.com/task/9548464000390658545) started by @applyuser160*