### PR TITLE
Fix Ryanpeiko and Chitoitsu duplicate calculation

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -498,20 +498,20 @@ pub fn judge_yaku(
         return result;
     }
 
-    if is_chitoitsu(&counts) && ctx.is_closed {
-        result.insert(YakuId::Chitoitsu);
-    }
-
-    if is_tanyao(&counts) {
-        result.insert(YakuId::Tanyao);
-    }
-
     if ctx.is_closed {
         if has_ryanpeiko(&patterns) {
             result.insert(YakuId::Ryanpeiko);
         } else if has_ipeiko(&patterns) {
             result.insert(YakuId::Ipeiko);
         }
+    }
+
+    if is_chitoitsu(&counts) && ctx.is_closed && !result.contains(&YakuId::Ryanpeiko) {
+        result.insert(YakuId::Chitoitsu);
+    }
+
+    if is_tanyao(&counts) {
+        result.insert(YakuId::Tanyao);
     }
 
     if let Some(y) = detect_pinfu(&patterns, &ctx) {

--- a/tests/test_chitoitsu_complex.rs
+++ b/tests/test_chitoitsu_complex.rs
@@ -4,7 +4,7 @@ use mahjong::yaku::{judge_yaku, WinContext, YakuId};
 #[test]
 fn test_chitoitsu_honitsu() {
     let tiles = vec![
-        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, FourM, FourM, FiveM, FiveM, SixM, SixM, Red, Red,
+        OneM, OneM, TwoM, TwoM, FourM, FourM, FiveM, FiveM, SevenM, SevenM, NineM, NineM, Red, Red,
     ];
 
     let result = judge_yaku(
@@ -22,8 +22,8 @@ fn test_chitoitsu_honitsu() {
 #[test]
 fn test_chitoitsu_chinitsu() {
     let tiles = vec![
-        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, FourM, FourM, FiveM, FiveM, SixM, SixM, SevenM,
-        SevenM,
+        OneM, OneM, TwoM, TwoM, FourM, FourM, FiveM, FiveM, SevenM, SevenM, EightM, EightM, NineM,
+        NineM,
     ];
 
     let result = judge_yaku(

--- a/tests/test_ryanpeiko_chitoitsu.rs
+++ b/tests/test_ryanpeiko_chitoitsu.rs
@@ -1,0 +1,15 @@
+use mahjong::yaku::{judge_yaku, WinContext, YakuId};
+use mahjong::tile::TileName::*;
+
+#[test]
+fn test_ryanpeiko_does_not_have_chitoitsu() {
+    let tiles = vec![
+        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM,
+        FourM, FourM, FiveM, FiveM, SixM, SixM,
+        SevenM, SevenM,
+    ];
+
+    let result = judge_yaku(&tiles, &[], WinContext::default());
+    assert!(result.contains(&YakuId::Ryanpeiko));
+    assert!(!result.contains(&YakuId::Chitoitsu));
+}

--- a/tests/test_ryanpeiko_chitoitsu.rs
+++ b/tests/test_ryanpeiko_chitoitsu.rs
@@ -1,12 +1,11 @@
-use mahjong::yaku::{judge_yaku, WinContext, YakuId};
 use mahjong::tile::TileName::*;
+use mahjong::yaku::{judge_yaku, WinContext, YakuId};
 
 #[test]
 fn test_ryanpeiko_does_not_have_chitoitsu() {
     let tiles = vec![
-        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM,
-        FourM, FourM, FiveM, FiveM, SixM, SixM,
-        SevenM, SevenM,
+        OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, FourM, FourM, FiveM, FiveM, SixM, SixM, SevenM,
+        SevenM,
     ];
 
     let result = judge_yaku(&tiles, &[], WinContext::default());


### PR DESCRIPTION
Fix Ryanpeiko and Chitoitsu duplicate calculation. Ensure `Chitoitsu` is not awarded if the hand also satisfies `Ryanpeiko`. Updated test hands for `Chitoitsu` + `Honitsu` and `Chitoitsu` + `Chinitsu` combinations as their previous hand definitions contained a `Ryanpeiko` pattern instead. Add a new regression test `test_ryanpeiko_does_not_have_chitoitsu` checking `Chitoitsu` is not awarded when `Ryanpeiko` is present.

---
*PR created automatically by Jules for task [9511678429160522807](https://jules.google.com/task/9511678429160522807) started by @applyuser160*