### PR TITLE
Refactor Round API for correct Kan state management

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,8 @@ pub fn play_once(seed: u64) -> PyResult<Vec<&'static str>> {
     let mut round = Round::new(wall);
     let mut discards = Vec::new();
 
-    while let Some(tile) = round.play_turn(0) {
+    while let Some(_drawn) = round.draw_tile() {
+        let tile = round.discard_tile(0).unwrap();
         discards.push(tile.as_str());
     }
 

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -43,22 +43,30 @@ impl Round {
         self.turn
     }
 
-    pub fn play_turn(&mut self, discard_index: usize) -> Option<TileName> {
+    pub fn draw_tile(&mut self) -> Option<TileName> {
         let drawn = self.wall.draw()?;
+        self.hands[self.turn].push(drawn);
+        Some(drawn)
+    }
+
+    pub fn discard_tile(&mut self, discard_index: usize) -> Result<TileName, &'static str> {
         let hand = &mut self.hands[self.turn];
-        hand.push(drawn);
-        let discarded = hand.discard(discard_index).ok()?;
+        let discarded = hand.discard(discard_index)?;
         self.rivers[self.turn].push(discarded);
         self.turn = (self.turn + 1) % PLAYER_NUMBER;
-        Some(discarded)
+        Ok(discarded)
     }
 
     pub fn play_meld(
         &mut self,
         player_index: usize,
         meld: Meld,
-        discard_index: usize,
-    ) -> Result<TileName, &'static str> {
+    ) -> Result<(), &'static str> {
+        if matches!(meld, Meld::Ankan(_) | Meld::Kakan(_))
+            && player_index != self.turn {
+                return Err("Ankan and Kakan can only be called on your own turn");
+            }
+
         let previous_player = (self.turn + PLAYER_NUMBER - 1) % PLAYER_NUMBER;
 
         if let Meld::Chii { .. } = meld {
@@ -119,27 +127,11 @@ impl Round {
             }
         }
 
-        let hand = &mut self.hands[player_index];
+        // Set turn to the player who called the meld. They will need to discard a tile next.
+        // For Daiminkan, Ankan, Kakan, they need to draw a replacement tile first, then discard.
+        self.turn = player_index;
 
-        // For Kan, we draw a replacement tile.
-        if let Meld::Daiminkan(_) | Meld::Ankan(_) | Meld::Kakan(_) = meld {
-            if let Some(drawn) = self.wall.draw() {
-                hand.push(drawn);
-            } else {
-                return Err("Wall is empty, cannot draw replacement tile for Kan");
-            }
-        }
-
-        let discarded = hand.discard(discard_index);
-        if let Err(_e) = discarded {
-            return Err("Discard Error");
-        }
-        self.rivers[player_index].push(discarded.unwrap());
-
-        // Update turn: the next turn belongs to the player after the one who called the meld
-        self.turn = (player_index + 1) % PLAYER_NUMBER;
-
-        Ok(discarded.unwrap())
+        Ok(())
     }
 
     fn deal(&mut self) {

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -101,31 +101,53 @@ impl Round {
             }
         }
 
-        // Apply meld to hand (this will fail if hand doesn't have the consumed tiles)
-        // Check condition before modifying the state
-        match meld {
-            Meld::Chii { called, .. } | Meld::Pon(called) | Meld::Daiminkan(called) => {
-                // Determine the last discarded tile
-                let last_discard = self.rivers[previous_player]
-                    .tiles()
-                    .last()
-                    .copied()
-                    .ok_or("No tile in river to call")?;
+        let original_hand = self.hands[player_index].clone();
+        let original_wall = self.wall.clone();
+        let original_river = self.rivers[previous_player].clone();
 
-                if last_discard != called {
-                    return Err("Called tile does not match the last discarded tile");
+        let res = (|| -> Result<(), &'static str> {
+            match meld {
+                Meld::Chii { called, .. } | Meld::Pon(called) | Meld::Daiminkan(called) => {
+                    // Determine the last discarded tile
+                    let last_discard = self.rivers[previous_player]
+                        .tiles()
+                        .last()
+                        .copied()
+                        .ok_or("No tile in river to call")?;
+
+                    if last_discard != called {
+                        return Err("Called tile does not match the last discarded tile");
+                    }
+
+                    self.hands[player_index].call_meld(meld)?;
+
+                    // Remove the tile from the previous player's river
+                    self.rivers[previous_player].pop();
                 }
-
-                self.hands[player_index].call_meld(meld)?;
-
-                // Remove the tile from the previous player's river
-                self.rivers[previous_player].pop();
+                Meld::Ankan(_) | Meld::Kakan(_) => {
+                    // For Ankan and Kakan, we do not depend on the previous player's discard.
+                    // We just call the meld directly.
+                    self.hands[player_index].call_meld(meld)?;
+                }
             }
-            Meld::Ankan(_) | Meld::Kakan(_) => {
-                // For Ankan and Kakan, we do not depend on the previous player's discard.
-                // We just call the meld directly.
-                self.hands[player_index].call_meld(meld)?;
+
+            // Draw a replacement tile for Kan
+            if matches!(meld, Meld::Daiminkan(_) | Meld::Ankan(_) | Meld::Kakan(_)) {
+                if let Some(replacement) = self.wall.draw_replacement() {
+                    self.hands[player_index].push(replacement);
+                } else {
+                    return Err("No replacement tile available in wall");
+                }
             }
+
+            Ok(())
+        })();
+
+        if let Err(err) = res {
+            self.hands[player_index] = original_hand;
+            self.wall = original_wall;
+            self.rivers[previous_player] = original_river;
+            return Err(err);
         }
 
         // Set turn to the player who called the meld. They will need to discard a tile next.

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -57,15 +57,10 @@ impl Round {
         Ok(discarded)
     }
 
-    pub fn play_meld(
-        &mut self,
-        player_index: usize,
-        meld: Meld,
-    ) -> Result<(), &'static str> {
-        if matches!(meld, Meld::Ankan(_) | Meld::Kakan(_))
-            && player_index != self.turn {
-                return Err("Ankan and Kakan can only be called on your own turn");
-            }
+    pub fn play_meld(&mut self, player_index: usize, meld: Meld) -> Result<(), &'static str> {
+        if matches!(meld, Meld::Ankan(_) | Meld::Kakan(_)) && player_index != self.turn {
+            return Err("Ankan and Kakan can only be called on your own turn");
+        }
 
         let previous_player = (self.turn + PLAYER_NUMBER - 1) % PLAYER_NUMBER;
 

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -96,7 +96,6 @@ mod tests {
                     // P3 has drawn the 4th tile. P3 calls Kakan!
                     let kakan_meld = Meld::Kakan(discarded);
                     round.play_meld(3, kakan_meld).unwrap();
-                    round.draw_tile();
                     let kakan_discard = round.discard_tile(0).unwrap();
 
                     // Verify wall decremented by 1 (replacement tile was drawn)

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -16,7 +16,10 @@ mod tests {
             w.shuffle(&mut StdRng::seed_from_u64(seed));
             let mut r = Round::new(w);
 
-            let discarded = { r.draw_tile(); r.discard_tile(0).unwrap() };
+            let discarded = {
+                r.draw_tile();
+                r.discard_tile(0).unwrap()
+            };
 
             let p2_hand = r.hand(3);
             let count = p2_hand.iter().filter(|&&t| t == discarded).count();
@@ -31,12 +34,15 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        let actual_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let actual_discard = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(actual_discard, discarded);
         assert_eq!(round.turn(), 2);
 
         let meld = Meld::Pon(discarded);
-        round.play_meld(3,     meld).unwrap();
+        round.play_meld(3, meld).unwrap();
         let p2_discard = round.discard_tile(0).unwrap();
 
         assert_eq!(round.turn(), 0);
@@ -55,12 +61,15 @@ mod tests {
         let mut round = Round::new(wall);
 
         // P1's turn
-        let actual_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let actual_discard = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(actual_discard, discarded);
 
         // P3 calls Pon!
         let meld = Meld::Pon(discarded);
-        round.play_meld(3,     meld).unwrap();
+        round.play_meld(3, meld).unwrap();
         let _ = round.discard_tile(0).unwrap();
         assert_eq!(round.turn(), 0);
 
@@ -114,11 +123,17 @@ mod tests {
         let wall = Wall::new();
         let mut round = Round::new(wall);
 
-        let discarded = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let discarded = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(round.river(1).tiles().len(), 1);
         assert_eq!(round.river(1).tiles()[0], discarded);
 
-        let discarded2 = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let discarded2 = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(round.river(2).tiles().len(), 1);
         assert_eq!(round.river(2).tiles()[0], discarded2);
     }
@@ -176,7 +191,7 @@ mod tests {
         let r3_len_before = round.river(3).tiles().len();
 
         let meld = Meld::Ankan(tile);
-        let res = round.play_meld(1,  meld);
+        let res = round.play_meld(1, meld);
 
         assert!(res.is_ok(), "Ankan should succeed");
 
@@ -230,28 +245,49 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P1 plays, turn -> 2
-        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P2 plays, turn -> 3
-        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P3 plays, turn -> 0
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        }; // P1 plays, turn -> 2
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        }; // P2 plays, turn -> 3
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        }; // P3 plays, turn -> 0
 
-        let p0_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let p0_discard = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(p0_discard, tile);
 
         let pon_meld = Meld::Pon(tile);
-        let res = round.play_meld(1,  pon_meld);
+        let res = round.play_meld(1, pon_meld);
         assert!(res.is_ok());
         round.discard_tile(0).unwrap(); // P1 discards after Pon, turn -> 2
 
-        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P2 plays, turn -> 3
-        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P3 plays, turn -> 0
-        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P0 plays, turn -> 1
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        }; // P2 plays, turn -> 3
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        }; // P3 plays, turn -> 0
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        }; // P0 plays, turn -> 1
 
         let kakan_meld = Meld::Kakan(tile);
         let r0_len = round.river(0).tiles().len();
         let r2_len = round.river(2).tiles().len();
         let r3_len = round.river(3).tiles().len();
 
-        let res_kakan = round.play_meld(1,  kakan_meld);
+        let res_kakan = round.play_meld(1, kakan_meld);
         assert!(res_kakan.is_ok(), "Kakan should succeed");
 
         assert_eq!(
@@ -279,7 +315,10 @@ mod tests {
         // Player 1 plays their turn.
         // With an unshuffled wall, Player 1 discards OneM.
         // Turn updates to Player 2.
-        let discarded = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let discarded = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(discarded, TileName::OneM);
         assert_eq!(round.turn(), 2);
 
@@ -293,7 +332,7 @@ mod tests {
 
         // Player 3 (index 3) attempts to call Chii.
         // Player 3 is NOT the immediate next player in order (not self.turn()), so it must fail.
-        let res3 = round.play_meld(3,  chii_meld);
+        let res3 = round.play_meld(3, chii_meld);
         assert!(res3.is_err());
         assert_eq!(
             res3.unwrap_err(),
@@ -302,7 +341,7 @@ mod tests {
 
         // Player 0 (index 0) attempts to call Chii.
         // Player 0 is NOT the immediate next player in order (not self.turn()), so it must fail.
-        let res0 = round.play_meld(0,  chii_meld);
+        let res0 = round.play_meld(0, chii_meld);
         assert!(res0.is_err());
         assert_eq!(
             res0.unwrap_err(),
@@ -310,7 +349,7 @@ mod tests {
         );
 
         // Player 2 (index 2) calls Chii. This is valid.
-        let res2 = round.play_meld(2,  chii_meld);
+        let res2 = round.play_meld(2, chii_meld);
         assert!(res2.is_ok());
     }
 
@@ -323,13 +362,28 @@ mod tests {
             let mut r = Round::new(w);
 
             // Let's play 4 turns so everyone has discarded 1 tile.
-            let _d1 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P1
-            let _d2 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P2
-            let _d3 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P3
-            let _d0 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P0
+            let _d1 = {
+                r.draw_tile();
+                r.discard_tile(0).unwrap()
+            }; // P1
+            let _d2 = {
+                r.draw_tile();
+                r.discard_tile(0).unwrap()
+            }; // P2
+            let _d3 = {
+                r.draw_tile();
+                r.discard_tile(0).unwrap()
+            }; // P3
+            let _d0 = {
+                r.draw_tile();
+                r.discard_tile(0).unwrap()
+            }; // P0
 
             // P1 plays again and discards their second tile.
-            let second_discard = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P1
+            let second_discard = {
+                r.draw_tile();
+                r.discard_tile(0).unwrap()
+            }; // P1
 
             // P3 has hand. Let's see if P3 has at least 2 of second_discard.
             let p3_hand = r.hand(3);
@@ -347,11 +401,26 @@ mod tests {
         let mut round = Round::new(wall);
 
         // Play 5 turns to get P1's river to have 2 tiles, and the last discard is `discarded`
-        let first_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
-        { round.draw_tile(); round.discard_tile(0).unwrap() };
-        { round.draw_tile(); round.discard_tile(0).unwrap() };
-        { round.draw_tile(); round.discard_tile(0).unwrap() };
-        let second_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let first_discard = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
+        {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
+        let second_discard = {
+            round.draw_tile();
+            round.discard_tile(0).unwrap()
+        };
         assert_eq!(second_discard, discarded);
 
         // Check P1 (index 1) river has 2 tiles

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -16,7 +16,7 @@ mod tests {
             w.shuffle(&mut StdRng::seed_from_u64(seed));
             let mut r = Round::new(w);
 
-            let discarded = r.play_turn(0).unwrap();
+            let discarded = { r.draw_tile(); r.discard_tile(0).unwrap() };
 
             let p2_hand = r.hand(3);
             let count = p2_hand.iter().filter(|&&t| t == discarded).count();
@@ -31,12 +31,13 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        let actual_discard = round.play_turn(0).unwrap();
+        let actual_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(actual_discard, discarded);
         assert_eq!(round.turn(), 2);
 
         let meld = Meld::Pon(discarded);
-        let p2_discard = round.play_meld(3, meld, 0).unwrap();
+        round.play_meld(3,     meld).unwrap();
+        let p2_discard = round.discard_tile(0).unwrap();
 
         assert_eq!(round.turn(), 0);
         assert_eq!(round.river(1).tiles().len(), 0);
@@ -54,12 +55,13 @@ mod tests {
         let mut round = Round::new(wall);
 
         // P1's turn
-        let actual_discard = round.play_turn(0).unwrap();
+        let actual_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(actual_discard, discarded);
 
         // P3 calls Pon!
         let meld = Meld::Pon(discarded);
-        let _ = round.play_meld(3, meld, 0).unwrap();
+        round.play_meld(3,     meld).unwrap();
+        let _ = round.discard_tile(0).unwrap();
         assert_eq!(round.turn(), 0);
 
         // For testing Kakan with the current play_meld implementation, we just need to
@@ -76,7 +78,7 @@ mod tests {
         loop {
             let turn = round.turn();
             if turn == 3 {
-                let _ = round.play_turn(0);
+                round.draw_tile();
 
                 let p3_hand = round.hand(3);
                 if p3_hand.contains(&discarded) {
@@ -84,18 +86,23 @@ mod tests {
 
                     // P3 has drawn the 4th tile. P3 calls Kakan!
                     let kakan_meld = Meld::Kakan(discarded);
-                    let kakan_discard = round.play_meld(3, kakan_meld, 0).unwrap();
+                    round.play_meld(3, kakan_meld).unwrap();
+                    round.draw_tile();
+                    let kakan_discard = round.discard_tile(0).unwrap();
 
                     // Verify wall decremented by 1 (replacement tile was drawn)
                     assert_eq!(round.wall().remaining(), remaining_before - 1);
                     assert_ne!(kakan_discard, TileName::None);
                     kakan_done = true;
                     break;
+                } else {
+                    let _ = round.discard_tile(0).unwrap();
                 }
             } else {
-                if round.play_turn(0).is_none() {
+                if round.draw_tile().is_none() {
                     break; // Wall empty
                 }
+                let _ = round.discard_tile(0).unwrap();
             }
         }
 
@@ -107,11 +114,11 @@ mod tests {
         let wall = Wall::new();
         let mut round = Round::new(wall);
 
-        let discarded = round.play_turn(0).unwrap();
+        let discarded = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(round.river(1).tiles().len(), 1);
         assert_eq!(round.river(1).tiles()[0], discarded);
 
-        let discarded2 = round.play_turn(0).unwrap();
+        let discarded2 = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(round.river(2).tiles().len(), 1);
         assert_eq!(round.river(2).tiles()[0], discarded2);
     }
@@ -130,7 +137,8 @@ mod tests {
             assert_eq!(round.hand(index).len(), 13);
         }
 
-        while let Some(tile) = round.play_turn(0) {
+        while let Some(_drawn) = round.draw_tile() {
+            let tile = round.discard_tile(0).unwrap();
             draws += 1;
             assert_ne!(tile, TileName::None);
         }
@@ -168,7 +176,7 @@ mod tests {
         let r3_len_before = round.river(3).tiles().len();
 
         let meld = Meld::Ankan(tile);
-        let res = round.play_meld(1, meld, 0);
+        let res = round.play_meld(1,  meld);
 
         assert!(res.is_ok(), "Ankan should succeed");
 
@@ -222,27 +230,28 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        round.play_turn(0).unwrap(); // P1 plays, turn -> 2
-        round.play_turn(0).unwrap(); // P2 plays, turn -> 3
-        round.play_turn(0).unwrap(); // P3 plays, turn -> 0
+        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P1 plays, turn -> 2
+        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P2 plays, turn -> 3
+        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P3 plays, turn -> 0
 
-        let p0_discard = round.play_turn(0).unwrap();
+        let p0_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(p0_discard, tile);
 
         let pon_meld = Meld::Pon(tile);
-        let res = round.play_meld(1, pon_meld, 0);
+        let res = round.play_meld(1,  pon_meld);
         assert!(res.is_ok());
+        round.discard_tile(0).unwrap(); // P1 discards after Pon, turn -> 2
 
-        round.play_turn(0).unwrap(); // P2 plays, turn -> 3
-        round.play_turn(0).unwrap(); // P3 plays, turn -> 0
-        round.play_turn(0).unwrap(); // P0 plays, turn -> 1
+        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P2 plays, turn -> 3
+        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P3 plays, turn -> 0
+        { round.draw_tile(); round.discard_tile(0).unwrap() }; // P0 plays, turn -> 1
 
         let kakan_meld = Meld::Kakan(tile);
         let r0_len = round.river(0).tiles().len();
         let r2_len = round.river(2).tiles().len();
         let r3_len = round.river(3).tiles().len();
 
-        let res_kakan = round.play_meld(1, kakan_meld, 0);
+        let res_kakan = round.play_meld(1,  kakan_meld);
         assert!(res_kakan.is_ok(), "Kakan should succeed");
 
         assert_eq!(
@@ -270,7 +279,7 @@ mod tests {
         // Player 1 plays their turn.
         // With an unshuffled wall, Player 1 discards OneM.
         // Turn updates to Player 2.
-        let discarded = round.play_turn(0).unwrap();
+        let discarded = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(discarded, TileName::OneM);
         assert_eq!(round.turn(), 2);
 
@@ -284,7 +293,7 @@ mod tests {
 
         // Player 3 (index 3) attempts to call Chii.
         // Player 3 is NOT the immediate next player in order (not self.turn()), so it must fail.
-        let res3 = round.play_meld(3, chii_meld, 0);
+        let res3 = round.play_meld(3,  chii_meld);
         assert!(res3.is_err());
         assert_eq!(
             res3.unwrap_err(),
@@ -293,7 +302,7 @@ mod tests {
 
         // Player 0 (index 0) attempts to call Chii.
         // Player 0 is NOT the immediate next player in order (not self.turn()), so it must fail.
-        let res0 = round.play_meld(0, chii_meld, 0);
+        let res0 = round.play_meld(0,  chii_meld);
         assert!(res0.is_err());
         assert_eq!(
             res0.unwrap_err(),
@@ -301,7 +310,7 @@ mod tests {
         );
 
         // Player 2 (index 2) calls Chii. This is valid.
-        let res2 = round.play_meld(2, chii_meld, 0);
+        let res2 = round.play_meld(2,  chii_meld);
         assert!(res2.is_ok());
     }
 
@@ -314,13 +323,13 @@ mod tests {
             let mut r = Round::new(w);
 
             // Let's play 4 turns so everyone has discarded 1 tile.
-            let _d1 = r.play_turn(0).unwrap(); // P1
-            let _d2 = r.play_turn(0).unwrap(); // P2
-            let _d3 = r.play_turn(0).unwrap(); // P3
-            let _d0 = r.play_turn(0).unwrap(); // P0
+            let _d1 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P1
+            let _d2 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P2
+            let _d3 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P3
+            let _d0 = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P0
 
             // P1 plays again and discards their second tile.
-            let second_discard = r.play_turn(0).unwrap(); // P1
+            let second_discard = { r.draw_tile(); r.discard_tile(0).unwrap() }; // P1
 
             // P3 has hand. Let's see if P3 has at least 2 of second_discard.
             let p3_hand = r.hand(3);
@@ -338,11 +347,11 @@ mod tests {
         let mut round = Round::new(wall);
 
         // Play 5 turns to get P1's river to have 2 tiles, and the last discard is `discarded`
-        let first_discard = round.play_turn(0).unwrap();
-        round.play_turn(0).unwrap();
-        round.play_turn(0).unwrap();
-        round.play_turn(0).unwrap();
-        let second_discard = round.play_turn(0).unwrap();
+        let first_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
+        { round.draw_tile(); round.discard_tile(0).unwrap() };
+        { round.draw_tile(); round.discard_tile(0).unwrap() };
+        { round.draw_tile(); round.discard_tile(0).unwrap() };
+        let second_discard = { round.draw_tile(); round.discard_tile(0).unwrap() };
         assert_eq!(second_discard, discarded);
 
         // Check P1 (index 1) river has 2 tiles
@@ -352,7 +361,8 @@ mod tests {
 
         // P3 (index 3) calls Pon on P1's discard
         let meld = Meld::Pon(discarded);
-        let p3_discard = round.play_meld(3, meld, 0).unwrap();
+        round.play_meld(3, meld).unwrap();
+        let p3_discard = round.discard_tile(0).unwrap();
 
         // Verify that ONLY the last discard was removed from P1's river.
         // First discard should still be there!


### PR DESCRIPTION
Refactored `Round` API to replace atomic `play_turn` with separate `draw_tile` and `discard_tile` methods, enabling players to execute self-turn melds (Ankan, Kakan) between drawing and discarding. Added turn validation in `play_meld` to prevent out-of-turn Ankan and Kakan declarations. Updated tests and library integrations to correctly utilize the new state machine.

---
*PR created automatically by Jules for task [6894557007608722535](https://jules.google.com/task/6894557007608722535) started by @applyuser160*