### PR TITLE
Add Suukantsu (四槓子) yakuman detection

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -33,6 +33,7 @@ pub enum YakuId {
     Daisangen,
     Shousuushi,
     Daisuushi,
+    Suukantsu,
     Tsuuiisou,
     Ryuuiisou,
     ChuurenPoutou,
@@ -279,6 +280,14 @@ pub const ALL_YAKU: &[Yaku] = &[
         id: YakuId::Daisuushi,
         name_ja: "大四喜",
         name_kana: "ダイスーシー",
+        han_closed: 13,
+        han_open: 13,
+        yakuman: true,
+    },
+    Yaku {
+        id: YakuId::Suukantsu,
+        name_ja: "四槓子",
+        name_kana: "スーカンツ",
         han_closed: 13,
         han_open: 13,
         yakuman: true,
@@ -568,6 +577,9 @@ pub fn judge_yaku(
         }
         if ctx.kan_count >= 3 {
             result.insert(YakuId::Sankantsu);
+        }
+        if ctx.kan_count >= 4 {
+            result.insert(YakuId::Suukantsu);
         }
         if is_suuankou(&patterns, ctx.is_closed, &ctx) {
             result.insert(YakuId::Suuankou);

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -28,6 +28,29 @@ mod tests {
     }
 
     #[test]
+    fn detect_suukantsu() {
+        let tiles = vec![
+            White, White, // pair
+        ];
+
+        // 4 Kans -> Suukantsu
+        let open_melds = vec![
+            mahjong::hand::Meld::Ankan(ThreeP),
+            mahjong::hand::Meld::Daiminkan(FourP),
+            mahjong::hand::Meld::Kakan(FiveP),
+            mahjong::hand::Meld::Ankan(SixP),
+        ];
+
+        let ctx = WinContext {
+            is_tsumo: true,
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &open_melds, ctx);
+        assert!(result.contains(&YakuId::Suukantsu));
+        assert!(!result.contains(&YakuId::Sankantsu)); // Normal yaku should be filtered out
+    }
+
+    #[test]
     fn detect_chitoitsu() {
         let tiles = vec![
             OneM, OneM, TwoM, TwoM, ThreeM, ThreeM, FourM, FourM, FiveP, FiveP, SixP, SixP, SevenS,


### PR DESCRIPTION
This PR implements the missing "Suukantsu" (四槓子) Yakuman.

Changes:
1. Added `Suukantsu` to `YakuId` enum.
2. Defined `Suukantsu` in `ALL_YAKU` as a 13 han Yakuman.
3. Updated `judge_yaku` to detect `Suukantsu` when `ctx.kan_count >= 4`.
4. Added `detect_suukantsu` test to verify the detection logic.

---
*PR created automatically by Jules for task [2178644878983610028](https://jules.google.com/task/2178644878983610028) started by @applyuser160*