### PR TITLE
Implement Dead Wall (Wanpai) and Kan replacement draws

### DIFF
--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -123,10 +123,10 @@ impl Round {
 
         // For Kan, we draw a replacement tile.
         if let Meld::Daiminkan(_) | Meld::Ankan(_) | Meld::Kakan(_) = meld {
-            if let Some(drawn) = self.wall.draw() {
+            if let Some(drawn) = self.wall.draw_replacement() {
                 hand.push(drawn);
             } else {
-                return Err("Wall is empty, cannot draw replacement tile for Kan");
+                return Err("Cannot draw replacement tile for Kan (possibly max kans reached)");
             }
         }
 

--- a/src/mahjong/wall.rs
+++ b/src/mahjong/wall.rs
@@ -7,6 +7,7 @@ use crate::tile::{TileName, TILE_NAME_NUMBER, TILE_PER_KIND, TILE_WALL_CAPACITY}
 pub struct Wall {
     tiles: [TileName; TILE_WALL_CAPACITY],
     cursor: usize,
+    kan_count: usize,
 }
 
 impl Wall {
@@ -19,15 +20,25 @@ impl Wall {
             tiles[offset..offset + TILE_PER_KIND].fill(tile_name);
         }
 
-        Self { tiles, cursor: 0 }
+        Self {
+            tiles,
+            cursor: 0,
+            kan_count: 0,
+        }
     }
 
     pub fn shuffle<R: Rng + ?Sized>(&mut self, rng: &mut R) {
         self.tiles.shuffle(rng);
         self.cursor = 0;
+        self.kan_count = 0;
     }
 
     pub fn draw(&mut self) -> Option<TileName> {
+        let limit = TILE_WALL_CAPACITY - 14 - self.kan_count;
+        if self.cursor >= limit {
+            return None;
+        }
+
         let tile = self.tiles.get(self.cursor).copied();
         if tile.is_some() {
             self.cursor += 1;
@@ -35,8 +46,21 @@ impl Wall {
         tile
     }
 
+    pub fn draw_replacement(&mut self) -> Option<TileName> {
+        if self.kan_count >= 4 {
+            return None;
+        }
+
+        let tile = self.tiles.get(TILE_WALL_CAPACITY - 1 - self.kan_count).copied();
+        if tile.is_some() {
+            self.kan_count += 1;
+        }
+        tile
+    }
+
     pub fn remaining(&self) -> usize {
-        TILE_WALL_CAPACITY.saturating_sub(self.cursor)
+        let limit = TILE_WALL_CAPACITY - 14 - self.kan_count;
+        limit.saturating_sub(self.cursor)
     }
 
     pub fn tiles(&self) -> &[TileName] {

--- a/src/mahjong/wall.rs
+++ b/src/mahjong/wall.rs
@@ -51,7 +51,10 @@ impl Wall {
             return None;
         }
 
-        let tile = self.tiles.get(TILE_WALL_CAPACITY - 1 - self.kan_count).copied();
+        let tile = self
+            .tiles
+            .get(TILE_WALL_CAPACITY - 1 - self.kan_count)
+            .copied();
         if tile.is_some() {
             self.kan_count += 1;
         }

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -178,7 +178,11 @@ mod tests {
         assert!(res.is_ok(), "Ankan should succeed");
 
         let remaining_after = round.wall().remaining();
-        assert_eq!(remaining_after, remaining_before - 1, "Drawing a replacement tile for a Kan should reduce the remaining drawable tiles by 1");
+        assert_eq!(
+            remaining_after,
+            remaining_before - 1,
+            "Drawing a replacement tile for a Kan should reduce the remaining drawable tiles by 1"
+        );
     }
 
     #[test]

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -136,7 +136,49 @@ mod tests {
         }
 
         let total_tiles = PLAYER_NUMBER * 13 + draws;
-        assert_eq!(total_tiles, TILE_WALL_CAPACITY);
+        assert_eq!(total_tiles, TILE_WALL_CAPACITY - 14);
+    }
+
+    #[test]
+    fn test_kan_draw_reduces_remaining() {
+        // Since we want to test Kan replacement draw logic, let's just create a deterministic setup
+        // Player 1 will Ankan, which means they need 4 identical tiles.
+        // The first 52 tiles are dealt to players.
+        // P0: 0, 4, 8...
+        // P1: 1, 5, 9...
+        // By default, Wall is ordered: 1m, 1m, 1m, 1m, 2m, 2m, 2m, 2m, ...
+        // Let's just find a seed where P1 gets an Ankan initially to simplify this test.
+        let mut found_ankan = None;
+        for seed in 0..1000 {
+            let mut w = Wall::new();
+            w.shuffle(&mut rand::rngs::StdRng::seed_from_u64(seed));
+            let r = Round::new(w);
+            let p1_hand = r.hand(1);
+            let mut counts = [0; 40];
+            for &t in p1_hand {
+                counts[t as usize] += 1;
+            }
+            if counts.iter().any(|&c| c == 4) {
+                let tile_idx = counts.iter().position(|&c| c == 4).unwrap();
+                found_ankan = Some((seed, TileName::from_usize(tile_idx)));
+                break;
+            }
+        }
+
+        let (seed, tile) = found_ankan.expect("Should find a seed with an Ankan in initial hand");
+        let mut wall = Wall::new();
+        wall.shuffle(&mut rand::rngs::StdRng::seed_from_u64(seed));
+        let mut round = Round::new(wall);
+
+        let remaining_before = round.wall().remaining();
+
+        let meld = Meld::Ankan(tile);
+        let res = round.play_meld(1, meld, 0);
+
+        assert!(res.is_ok(), "Ankan should succeed");
+
+        let remaining_after = round.wall().remaining();
+        assert_eq!(remaining_after, remaining_before - 1, "Drawing a replacement tile for a Kan should reduce the remaining drawable tiles by 1");
     }
 
     #[test]

--- a/tests/test_wall.rs
+++ b/tests/test_wall.rs
@@ -15,7 +15,7 @@ mod tests {
             *counter.entry(*tile).or_default() += 1;
         }
 
-        assert_eq!(wall.remaining(), TILE_WALL_CAPACITY);
+        assert_eq!(wall.remaining(), TILE_WALL_CAPACITY - 14);
         assert_eq!(counter.len(), TILE_NAME_NUMBER);
         for value in counter.values() {
             assert_eq!(*value, TILE_PER_KIND);


### PR DESCRIPTION
- Added a `kan_count` tracker to the `Wall` struct to manage Dead Wall state.
- Updated `Wall::draw` and `Wall::remaining` to enforce the 14-tile dead wall limit.
- Introduced `Wall::draw_replacement` to correctly draw Kan replacement tiles from the end of the wall, decrementing the available regular draws.
- Updated `Round::play_meld` to correctly fetch Kan replacement tiles using `draw_replacement`.
- Updated unit tests (`test_wall.rs` and `test_round.rs`) to reflect the new 122-tile limit and verify Kan substitution logic accurately reduces remaining count.

---
*PR created automatically by Jules for task [13965213655934873234](https://jules.google.com/task/13965213655934873234) started by @applyuser160*