### PR TITLE
fix: properly validate terminal pair for junchan

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -1108,7 +1108,7 @@ fn is_chinitsu(counts: &[usize; 35]) -> bool {
 
 fn is_junchan(patterns: &[HandPattern]) -> bool {
     patterns.iter().any(|pattern| {
-        if is_honor(pattern.pair) {
+        if !is_terminal(pattern.pair) {
             return false;
         }
         pattern.all_melds().all(|meld| match meld {

--- a/tests/test_junchan.rs
+++ b/tests/test_junchan.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests {
+    use mahjong::tile::TileName::*;
+    use mahjong::yaku::{judge_yaku, WinContext, YakuId};
+
+    #[test]
+    fn test_junchan_invalid_pair() {
+        // Test case where pair is non-terminal (e.g. 5m) but melds all have terminals
+        // This should NOT be junchan.
+        let tiles = vec![
+            OneM, TwoM, ThreeM, // 123m
+            SevenM, EightM, NineM, // 789m
+            OneP, TwoP, ThreeP, // 123p
+            SevenS, EightS, NineS, // 789s
+            FiveM, FiveM, // 5m pair - Invalid for junchan
+        ];
+
+        let ctx = WinContext {
+            is_closed: true,
+            is_tsumo: true,
+            win_tile: Some(OneM),
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &[], ctx);
+        assert!(!result.contains(&YakuId::Junchan), "Junchan should not be valid with a non-terminal pair");
+    }
+
+    #[test]
+    fn test_junchan_valid_pair() {
+        // Test case where pair is terminal (e.g. 1m) and melds all have terminals
+        // This SHOULD be junchan.
+        let tiles = vec![
+            OneM, TwoM, ThreeM, // 123m
+            SevenM, EightM, NineM, // 789m
+            OneP, TwoP, ThreeP, // 123p
+            SevenS, EightS, NineS, // 789s
+            NineP, NineP, // 9p pair - Valid for junchan
+        ];
+
+        let ctx = WinContext {
+            is_closed: true,
+            is_tsumo: true,
+            win_tile: Some(OneM),
+            ..Default::default()
+        };
+        let result = judge_yaku(&tiles, &[], ctx);
+        assert!(result.contains(&YakuId::Junchan), "Junchan should be valid with a terminal pair");
+    }
+}

--- a/tests/test_junchan.rs
+++ b/tests/test_junchan.rs
@@ -22,7 +22,10 @@ mod tests {
             ..Default::default()
         };
         let result = judge_yaku(&tiles, &[], ctx);
-        assert!(!result.contains(&YakuId::Junchan), "Junchan should not be valid with a non-terminal pair");
+        assert!(
+            !result.contains(&YakuId::Junchan),
+            "Junchan should not be valid with a non-terminal pair"
+        );
     }
 
     #[test]
@@ -44,6 +47,9 @@ mod tests {
             ..Default::default()
         };
         let result = judge_yaku(&tiles, &[], ctx);
-        assert!(result.contains(&YakuId::Junchan), "Junchan should be valid with a terminal pair");
+        assert!(
+            result.contains(&YakuId::Junchan),
+            "Junchan should be valid with a terminal pair"
+        );
     }
 }


### PR DESCRIPTION
- The `is_junchan` logic previously only verified that the pair was not an honor tile, incorrectly allowing middle simple tiles (2-8) to act as the pair.
- Updated the pair check to correctly ensure that the pair is a terminal tile via `is_terminal(pattern.pair)`.
- Added test coverage in `tests/test_junchan.rs` to verify validation of terminal and non-terminal pairs.

---
*PR created automatically by Jules for task [13914081760867698313](https://jules.google.com/task/13914081760867698313) started by @applyuser160*