### PR TITLE
Add standard situational yaku

### DIFF
--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -38,6 +38,12 @@ pub enum YakuId {
     ChuurenPoutou,
     Tenhou,
     Chiihou,
+    RinshanKaihou,
+    Chankan,
+    HaiteiRaoyue,
+    HouteiRaoyui,
+    DoubleRiichi,
+    Ippatsu,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -323,6 +329,54 @@ pub const ALL_YAKU: &[Yaku] = &[
         han_open: 0,
         yakuman: true,
     },
+    Yaku {
+        id: YakuId::RinshanKaihou,
+        name_ja: "嶺上開花",
+        name_kana: "リンシャンカイホウ",
+        han_closed: 1,
+        han_open: 1,
+        yakuman: false,
+    },
+    Yaku {
+        id: YakuId::Chankan,
+        name_ja: "槍槓",
+        name_kana: "チャンカン",
+        han_closed: 1,
+        han_open: 1,
+        yakuman: false,
+    },
+    Yaku {
+        id: YakuId::HaiteiRaoyue,
+        name_ja: "海底撈月",
+        name_kana: "ハイテイラオユエ",
+        han_closed: 1,
+        han_open: 1,
+        yakuman: false,
+    },
+    Yaku {
+        id: YakuId::HouteiRaoyui,
+        name_ja: "河底撈魚",
+        name_kana: "ホウテイラオユイ",
+        han_closed: 1,
+        han_open: 1,
+        yakuman: false,
+    },
+    Yaku {
+        id: YakuId::DoubleRiichi,
+        name_ja: "ダブル立直",
+        name_kana: "ダブルリーチ",
+        han_closed: 2,
+        han_open: 0,
+        yakuman: false,
+    },
+    Yaku {
+        id: YakuId::Ippatsu,
+        name_ja: "一発",
+        name_kana: "イッパツ",
+        han_closed: 1,
+        han_open: 0,
+        yakuman: false,
+    },
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -356,6 +410,12 @@ pub struct WinContext {
     pub tenhou: bool,
     pub chiihou: bool,
     pub win_tile: Option<TileName>,
+    pub is_rinshan: bool,
+    pub is_chankan: bool,
+    pub is_haitei: bool,
+    pub is_houtei: bool,
+    pub is_double_riichi: bool,
+    pub is_ippatsu: bool,
 }
 
 impl Default for WinContext {
@@ -370,6 +430,12 @@ impl Default for WinContext {
             tenhou: false,
             chiihou: false,
             win_tile: None,
+            is_rinshan: false,
+            is_chankan: false,
+            is_haitei: false,
+            is_houtei: false,
+            is_double_riichi: false,
+            is_ippatsu: false,
         }
     }
 }
@@ -462,8 +528,30 @@ pub fn judge_yaku(
     // (excluding open melds). Otherwise, it tries to re-parse the open meld tiles.
     let patterns = generate_patterns(&closed_counts, &open_melds, &closed_melds);
 
-    if ctx.riichi && ctx.is_closed {
+    if ctx.is_double_riichi && ctx.is_closed {
+        result.insert(YakuId::DoubleRiichi);
+    } else if ctx.riichi && ctx.is_closed {
         result.insert(YakuId::Riichi);
+    }
+
+    if ctx.is_ippatsu && ctx.is_closed && (ctx.riichi || ctx.is_double_riichi) {
+        result.insert(YakuId::Ippatsu);
+    }
+
+    if ctx.is_rinshan && ctx.is_tsumo {
+        result.insert(YakuId::RinshanKaihou);
+    }
+
+    if ctx.is_chankan && !ctx.is_tsumo {
+        result.insert(YakuId::Chankan);
+    }
+
+    if ctx.is_haitei && ctx.is_tsumo {
+        result.insert(YakuId::HaiteiRaoyue);
+    }
+
+    if ctx.is_houtei && !ctx.is_tsumo {
+        result.insert(YakuId::HouteiRaoyui);
     }
 
     if ctx.is_closed && ctx.is_tsumo {

--- a/tests/test_yaku_context.rs
+++ b/tests/test_yaku_context.rs
@@ -1,0 +1,85 @@
+use mahjong::yaku::{judge_yaku, WinContext, YakuId};
+use mahjong::tile::TileName;
+
+fn create_valid_hand() -> Vec<TileName> {
+    // A simple complete hand: 123m, 456m, 789m, 11z, 222z
+    vec![
+        TileName::OneM, TileName::TwoM, TileName::ThreeM,
+        TileName::FourM, TileName::FiveM, TileName::SixM,
+        TileName::SevenM, TileName::EightM, TileName::NineM,
+        TileName::East, TileName::East,
+        TileName::South, TileName::South, TileName::South,
+    ]
+}
+
+#[test]
+fn test_rinshan_kaihou() {
+    let tiles = create_valid_hand();
+    let mut ctx = WinContext::default();
+    ctx.is_tsumo = true;
+    ctx.is_rinshan = true;
+
+    let yaku = judge_yaku(&tiles, &[], ctx);
+    assert!(yaku.contains(&YakuId::RinshanKaihou));
+}
+
+#[test]
+fn test_chankan() {
+    let tiles = create_valid_hand();
+    let mut ctx = WinContext::default();
+    ctx.is_tsumo = false;
+    ctx.is_chankan = true;
+
+    let yaku = judge_yaku(&tiles, &[], ctx);
+    assert!(yaku.contains(&YakuId::Chankan));
+}
+
+#[test]
+fn test_haitei_raoyue() {
+    let tiles = create_valid_hand();
+    let mut ctx = WinContext::default();
+    ctx.is_tsumo = true;
+    ctx.is_haitei = true;
+
+    let yaku = judge_yaku(&tiles, &[], ctx);
+    assert!(yaku.contains(&YakuId::HaiteiRaoyue));
+}
+
+#[test]
+fn test_houtei_raoyui() {
+    let tiles = create_valid_hand();
+    let mut ctx = WinContext::default();
+    ctx.is_tsumo = false;
+    ctx.is_houtei = true;
+
+    let yaku = judge_yaku(&tiles, &[], ctx);
+    assert!(yaku.contains(&YakuId::HouteiRaoyui));
+}
+
+#[test]
+fn test_double_riichi_and_ippatsu() {
+    let tiles = create_valid_hand();
+    let mut ctx = WinContext::default();
+    ctx.is_double_riichi = true;
+    ctx.is_ippatsu = true;
+    ctx.is_closed = true;
+
+    let yaku = judge_yaku(&tiles, &[], ctx);
+    assert!(yaku.contains(&YakuId::DoubleRiichi));
+    assert!(yaku.contains(&YakuId::Ippatsu));
+    assert!(!yaku.contains(&YakuId::Riichi)); // Double Riichi supersedes Riichi
+}
+
+#[test]
+fn test_ippatsu_with_normal_riichi() {
+    let tiles = create_valid_hand();
+    let mut ctx = WinContext::default();
+    ctx.riichi = true;
+    ctx.is_ippatsu = true;
+    ctx.is_closed = true;
+
+    let yaku = judge_yaku(&tiles, &[], ctx);
+    assert!(yaku.contains(&YakuId::Riichi));
+    assert!(yaku.contains(&YakuId::Ippatsu));
+    assert!(!yaku.contains(&YakuId::DoubleRiichi));
+}

--- a/tests/test_yaku_context.rs
+++ b/tests/test_yaku_context.rs
@@ -1,14 +1,23 @@
-use mahjong::yaku::{judge_yaku, WinContext, YakuId};
 use mahjong::tile::TileName;
+use mahjong::yaku::{judge_yaku, WinContext, YakuId};
 
 fn create_valid_hand() -> Vec<TileName> {
     // A simple complete hand: 123m, 456m, 789m, 11z, 222z
     vec![
-        TileName::OneM, TileName::TwoM, TileName::ThreeM,
-        TileName::FourM, TileName::FiveM, TileName::SixM,
-        TileName::SevenM, TileName::EightM, TileName::NineM,
-        TileName::East, TileName::East,
-        TileName::South, TileName::South, TileName::South,
+        TileName::OneM,
+        TileName::TwoM,
+        TileName::ThreeM,
+        TileName::FourM,
+        TileName::FiveM,
+        TileName::SixM,
+        TileName::SevenM,
+        TileName::EightM,
+        TileName::NineM,
+        TileName::East,
+        TileName::East,
+        TileName::South,
+        TileName::South,
+        TileName::South,
     ]
 }
 


### PR DESCRIPTION
Added definitions and logic for Rinshan Kaihou, Chankan, Haitei Raoyue, Houtei Raoyui, Double Riichi, and Ippatsu. Updates include adding these to `YakuId` enum and `ALL_YAKU`, updating `WinContext` with relevant boolean flags, handling them in `judge_yaku` with proper rules (e.g., Double Riichi supersedes Riichi), and adding a new test suite specifically for these.

---
*PR created automatically by Jules for task [2144815251311609585](https://jules.google.com/task/2144815251311609585) started by @applyuser160*