### PR TITLE
Refactor Round turn phases for Tsumo and Rinshan Kaihou

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,12 @@ pub fn play_once(seed: u64) -> PyResult<Vec<&'static str>> {
     let mut round = Round::new(wall);
     let mut discards = Vec::new();
 
-    while let Some(tile) = round.play_turn(0) {
-        discards.push(tile.as_str());
+    while round.draw_tile().is_some() {
+        if let Ok(tile) = round.discard_tile(0) {
+            discards.push(tile.as_str());
+        } else {
+            break;
+        }
     }
 
     Ok(discards)

--- a/src/mahjong/round.rs
+++ b/src/mahjong/round.rs
@@ -43,27 +43,32 @@ impl Round {
         self.turn
     }
 
-    pub fn play_turn(&mut self, discard_index: usize) -> Option<TileName> {
+    pub fn draw_tile(&mut self) -> Option<TileName> {
         let drawn = self.wall.draw()?;
-        let hand = &mut self.hands[self.turn];
-        hand.push(drawn);
-        let discarded = hand.discard(discard_index).ok()?;
-        self.rivers[self.turn].push(discarded);
-        self.turn = (self.turn + 1) % PLAYER_NUMBER;
-        Some(discarded)
+        self.hands[self.turn].push(drawn);
+        Some(drawn)
     }
 
-    pub fn play_meld(
-        &mut self,
-        player_index: usize,
-        meld: Meld,
-        discard_index: usize,
-    ) -> Result<TileName, &'static str> {
+    pub fn discard_tile(&mut self, discard_index: usize) -> Result<TileName, &'static str> {
+        let hand = &mut self.hands[self.turn];
+        let discarded = hand.discard(discard_index).map_err(|_| "Discard Error")?;
+        self.rivers[self.turn].push(discarded);
+        self.turn = (self.turn + 1) % PLAYER_NUMBER;
+        Ok(discarded)
+    }
+
+    pub fn play_meld(&mut self, player_index: usize, meld: Meld) -> Result<(), &'static str> {
         let previous_player = (self.turn + PLAYER_NUMBER - 1) % PLAYER_NUMBER;
 
         if let Meld::Chii { .. } = meld {
             if player_index != self.turn {
                 return Err("Chii can only be called from the Kamicha (previous player)");
+            }
+        }
+
+        if let Meld::Ankan(_) | Meld::Kakan(_) = meld {
+            if player_index != self.turn {
+                return Err("Self meld (Ankan/Kakan) can only be called on the player's own turn");
             }
         }
 
@@ -130,16 +135,10 @@ impl Round {
             }
         }
 
-        let discarded = hand.discard(discard_index);
-        if let Err(_e) = discarded {
-            return Err("Discard Error");
-        }
-        self.rivers[player_index].push(discarded.unwrap());
+        // Set turn to the player who called the meld, so they can discard next
+        self.turn = player_index;
 
-        // Update turn: the next turn belongs to the player after the one who called the meld
-        self.turn = (player_index + 1) % PLAYER_NUMBER;
-
-        Ok(discarded.unwrap())
+        Ok(())
     }
 
     fn deal(&mut self) {

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -16,7 +16,8 @@ mod tests {
             w.shuffle(&mut StdRng::seed_from_u64(seed));
             let mut r = Round::new(w);
 
-            let discarded = r.play_turn(0).unwrap();
+            r.draw_tile().unwrap();
+            let discarded = r.discard_tile(0).unwrap();
 
             let p2_hand = r.hand(3);
             let count = p2_hand.iter().filter(|&&t| t == discarded).count();
@@ -31,12 +32,14 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        let actual_discard = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let actual_discard = round.discard_tile(0).unwrap();
         assert_eq!(actual_discard, discarded);
         assert_eq!(round.turn(), 2);
 
         let meld = Meld::Pon(discarded);
-        let p2_discard = round.play_meld(3, meld, 0).unwrap();
+        round.play_meld(3, meld).unwrap();
+        let p2_discard = round.discard_tile(0).unwrap();
 
         assert_eq!(round.turn(), 0);
         assert_eq!(round.river(1).tiles().len(), 0);
@@ -54,12 +57,14 @@ mod tests {
         let mut round = Round::new(wall);
 
         // P1's turn
-        let actual_discard = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let actual_discard = round.discard_tile(0).unwrap();
         assert_eq!(actual_discard, discarded);
 
         // P3 calls Pon!
         let meld = Meld::Pon(discarded);
-        let _ = round.play_meld(3, meld, 0).unwrap();
+        round.play_meld(3, meld).unwrap();
+        let _ = round.discard_tile(0).unwrap();
         assert_eq!(round.turn(), 0);
 
         // For testing Kakan with the current play_meld implementation, we just need to
@@ -76,7 +81,7 @@ mod tests {
         loop {
             let turn = round.turn();
             if turn == 3 {
-                let _ = round.play_turn(0);
+                let _ = round.draw_tile();
 
                 let p3_hand = round.hand(3);
                 if p3_hand.contains(&discarded) {
@@ -84,18 +89,22 @@ mod tests {
 
                     // P3 has drawn the 4th tile. P3 calls Kakan!
                     let kakan_meld = Meld::Kakan(discarded);
-                    let kakan_discard = round.play_meld(3, kakan_meld, 0).unwrap();
+                    round.play_meld(3, kakan_meld).unwrap();
+                    let kakan_discard = round.discard_tile(0).unwrap();
 
                     // Verify wall decremented by 1 (replacement tile was drawn)
                     assert_eq!(round.wall().remaining(), remaining_before - 1);
                     assert_ne!(kakan_discard, TileName::None);
                     kakan_done = true;
                     break;
+                } else {
+                    let _ = round.discard_tile(0);
                 }
             } else {
-                if round.play_turn(0).is_none() {
+                if round.draw_tile().is_none() {
                     break; // Wall empty
                 }
+                let _ = round.discard_tile(0);
             }
         }
 
@@ -107,11 +116,13 @@ mod tests {
         let wall = Wall::new();
         let mut round = Round::new(wall);
 
-        let discarded = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let discarded = round.discard_tile(0).unwrap();
         assert_eq!(round.river(1).tiles().len(), 1);
         assert_eq!(round.river(1).tiles()[0], discarded);
 
-        let discarded2 = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let discarded2 = round.discard_tile(0).unwrap();
         assert_eq!(round.river(2).tiles().len(), 1);
         assert_eq!(round.river(2).tiles()[0], discarded2);
     }
@@ -130,7 +141,8 @@ mod tests {
             assert_eq!(round.hand(index).len(), 13);
         }
 
-        while let Some(tile) = round.play_turn(0) {
+        while let Some(_) = round.draw_tile() {
+            let tile = round.discard_tile(0).unwrap();
             draws += 1;
             assert_ne!(tile, TileName::None);
         }
@@ -168,7 +180,7 @@ mod tests {
         let r3_len_before = round.river(3).tiles().len();
 
         let meld = Meld::Ankan(tile);
-        let res = round.play_meld(1, meld, 0);
+        let res = round.play_meld(1, meld);
 
         assert!(res.is_ok(), "Ankan should succeed");
 
@@ -222,27 +234,35 @@ mod tests {
         wall.shuffle(&mut StdRng::seed_from_u64(seed));
         let mut round = Round::new(wall);
 
-        round.play_turn(0).unwrap(); // P1 plays, turn -> 2
-        round.play_turn(0).unwrap(); // P2 plays, turn -> 3
-        round.play_turn(0).unwrap(); // P3 plays, turn -> 0
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap(); // P1 plays, turn -> 2
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap(); // P2 plays, turn -> 3
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap(); // P3 plays, turn -> 0
 
-        let p0_discard = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let p0_discard = round.discard_tile(0).unwrap();
         assert_eq!(p0_discard, tile);
 
         let pon_meld = Meld::Pon(tile);
-        let res = round.play_meld(1, pon_meld, 0);
+        let res = round.play_meld(1, pon_meld);
         assert!(res.is_ok());
+        let _ = round.discard_tile(0).unwrap(); // P1 discards after pon
 
-        round.play_turn(0).unwrap(); // P2 plays, turn -> 3
-        round.play_turn(0).unwrap(); // P3 plays, turn -> 0
-        round.play_turn(0).unwrap(); // P0 plays, turn -> 1
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap(); // P2 plays, turn -> 3
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap(); // P3 plays, turn -> 0
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap(); // P0 plays, turn -> 1
 
         let kakan_meld = Meld::Kakan(tile);
         let r0_len = round.river(0).tiles().len();
         let r2_len = round.river(2).tiles().len();
         let r3_len = round.river(3).tiles().len();
 
-        let res_kakan = round.play_meld(1, kakan_meld, 0);
+        let res_kakan = round.play_meld(1, kakan_meld);
         assert!(res_kakan.is_ok(), "Kakan should succeed");
 
         assert_eq!(
@@ -270,7 +290,8 @@ mod tests {
         // Player 1 plays their turn.
         // With an unshuffled wall, Player 1 discards OneM.
         // Turn updates to Player 2.
-        let discarded = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let discarded = round.discard_tile(0).unwrap();
         assert_eq!(discarded, TileName::OneM);
         assert_eq!(round.turn(), 2);
 
@@ -284,7 +305,7 @@ mod tests {
 
         // Player 3 (index 3) attempts to call Chii.
         // Player 3 is NOT the immediate next player in order (not self.turn()), so it must fail.
-        let res3 = round.play_meld(3, chii_meld, 0);
+        let res3 = round.play_meld(3, chii_meld);
         assert!(res3.is_err());
         assert_eq!(
             res3.unwrap_err(),
@@ -293,7 +314,7 @@ mod tests {
 
         // Player 0 (index 0) attempts to call Chii.
         // Player 0 is NOT the immediate next player in order (not self.turn()), so it must fail.
-        let res0 = round.play_meld(0, chii_meld, 0);
+        let res0 = round.play_meld(0, chii_meld);
         assert!(res0.is_err());
         assert_eq!(
             res0.unwrap_err(),
@@ -301,7 +322,7 @@ mod tests {
         );
 
         // Player 2 (index 2) calls Chii. This is valid.
-        let res2 = round.play_meld(2, chii_meld, 0);
+        let res2 = round.play_meld(2, chii_meld);
         assert!(res2.is_ok());
     }
 
@@ -314,13 +335,18 @@ mod tests {
             let mut r = Round::new(w);
 
             // Let's play 4 turns so everyone has discarded 1 tile.
-            let _d1 = r.play_turn(0).unwrap(); // P1
-            let _d2 = r.play_turn(0).unwrap(); // P2
-            let _d3 = r.play_turn(0).unwrap(); // P3
-            let _d0 = r.play_turn(0).unwrap(); // P0
+            r.draw_tile().unwrap();
+            let _d1 = r.discard_tile(0).unwrap(); // P1
+            r.draw_tile().unwrap();
+            let _d2 = r.discard_tile(0).unwrap(); // P2
+            r.draw_tile().unwrap();
+            let _d3 = r.discard_tile(0).unwrap(); // P3
+            r.draw_tile().unwrap();
+            let _d0 = r.discard_tile(0).unwrap(); // P0
 
             // P1 plays again and discards their second tile.
-            let second_discard = r.play_turn(0).unwrap(); // P1
+            r.draw_tile().unwrap();
+            let second_discard = r.discard_tile(0).unwrap(); // P1
 
             // P3 has hand. Let's see if P3 has at least 2 of second_discard.
             let p3_hand = r.hand(3);
@@ -338,11 +364,16 @@ mod tests {
         let mut round = Round::new(wall);
 
         // Play 5 turns to get P1's river to have 2 tiles, and the last discard is `discarded`
-        let first_discard = round.play_turn(0).unwrap();
-        round.play_turn(0).unwrap();
-        round.play_turn(0).unwrap();
-        round.play_turn(0).unwrap();
-        let second_discard = round.play_turn(0).unwrap();
+        round.draw_tile().unwrap();
+        let first_discard = round.discard_tile(0).unwrap();
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap();
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap();
+        round.draw_tile().unwrap();
+        round.discard_tile(0).unwrap();
+        round.draw_tile().unwrap();
+        let second_discard = round.discard_tile(0).unwrap();
         assert_eq!(second_discard, discarded);
 
         // Check P1 (index 1) river has 2 tiles
@@ -352,7 +383,8 @@ mod tests {
 
         // P3 (index 3) calls Pon on P1's discard
         let meld = Meld::Pon(discarded);
-        let p3_discard = round.play_meld(3, meld, 0).unwrap();
+        round.play_meld(3, meld).unwrap();
+        let p3_discard = round.discard_tile(0).unwrap();
 
         // Verify that ONLY the last discard was removed from P1's river.
         // First discard should still be there!


### PR DESCRIPTION
Refactored Round API into `draw_tile` and `discard_tile` allowing for intermediate action processing, such as winning on a draw or via a Kan.

---
*PR created automatically by Jules for task [7545659642682790808](https://jules.google.com/task/7545659642682790808) started by @applyuser160*