### PR TITLE
feat: Add PyO3 Python bindings for Mahjong library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Cargo.lock
 #.idea/
 
 .env/
+.venv/

--- a/benches/mahjong_benchmark.rs
+++ b/benches/mahjong_benchmark.rs
@@ -1,5 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+fn sum(a: i32, b: i32) -> i32 {
+    a + b
+}
+
 fn bench_sum(c: &mut Criterion) {
     c.bench_function("sum", |b| b.iter(|| sum(black_box(2), black_box(2))));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub use tile::{
 pub use wall::Wall;
 pub use yaku::{judge_yaku, WinContext, Yaku, YakuId, ALL_YAKU};
 
+pub mod python_api;
+
 #[pyfunction]
 pub fn play_once(seed: u64) -> PyResult<Vec<&'static str>> {
     let mut wall = Wall::new();
@@ -50,5 +52,19 @@ pub fn play_once(seed: u64) -> PyResult<Vec<&'static str>> {
 #[pymodule]
 fn mahjong(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(play_once, m)?)?;
+    m.add_class::<python_api::PyTileType>()?;
+    m.add_class::<python_api::PyTileCategory>()?;
+    m.add_class::<python_api::PyTileName>()?;
+    m.add_class::<python_api::PyTile>()?;
+    m.add_class::<python_api::PyMeld>()?;
+    m.add_class::<python_api::PyHand>()?;
+    m.add_class::<python_api::PyRiver>()?;
+    m.add_class::<python_api::PyWall>()?;
+    m.add_class::<python_api::PyRound>()?;
+    m.add_class::<python_api::PyYakuId>()?;
+    m.add_class::<python_api::PyYaku>()?;
+    m.add_class::<python_api::PyWinContext>()?;
+    m.add_function(wrap_pyfunction!(python_api::get_all_yaku, m)?)?;
+    m.add_function(wrap_pyfunction!(python_api::py_judge_yaku, m)?)?;
     Ok(())
 }

--- a/src/mahjong/__init__.py
+++ b/src/mahjong/__init__.py
@@ -1,0 +1,1 @@
+from .mahjong import *

--- a/src/python_api.rs
+++ b/src/python_api.rs
@@ -1,7 +1,6 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-
 use crate::hand::{Hand, Meld};
 use crate::river::River;
 use crate::round::Round;

--- a/src/python_api.rs
+++ b/src/python_api.rs
@@ -1,0 +1,795 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+
+use crate::hand::{Hand, Meld};
+use crate::river::River;
+use crate::round::Round;
+use crate::tile::{Tile, TileCategory, TileName, TileType};
+use crate::wall::Wall;
+use crate::yaku::{judge_yaku, WinContext, Yaku, YakuId, ALL_YAKU};
+
+// ==========================================
+// 1. Tile related wrappers
+// ==========================================
+
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum PyTileType {
+    None = 0,
+    Characters,
+    Circles,
+    Bamboos,
+    Winds,
+    Dragons,
+}
+
+impl From<TileType> for PyTileType {
+    fn from(t: TileType) -> Self {
+        match t {
+            TileType::None => PyTileType::None,
+            TileType::Characters => PyTileType::Characters,
+            TileType::Circles => PyTileType::Circles,
+            TileType::Bamboos => PyTileType::Bamboos,
+            TileType::Winds => PyTileType::Winds,
+            TileType::Dragons => PyTileType::Dragons,
+        }
+    }
+}
+
+impl Into<TileType> for PyTileType {
+    fn into(self) -> TileType {
+        match self {
+            PyTileType::None => TileType::None,
+            PyTileType::Characters => TileType::Characters,
+            PyTileType::Circles => TileType::Circles,
+            PyTileType::Bamboos => TileType::Bamboos,
+            PyTileType::Winds => TileType::Winds,
+            PyTileType::Dragons => TileType::Dragons,
+        }
+    }
+}
+
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum PyTileCategory {
+    None = 0,
+    Simples,
+    Honors,
+}
+
+impl From<TileCategory> for PyTileCategory {
+    fn from(c: TileCategory) -> Self {
+        match c {
+            TileCategory::None => PyTileCategory::None,
+            TileCategory::Simples => PyTileCategory::Simples,
+            TileCategory::Honors => PyTileCategory::Honors,
+        }
+    }
+}
+
+impl Into<TileCategory> for PyTileCategory {
+    fn into(self) -> TileCategory {
+        match self {
+            PyTileCategory::None => TileCategory::None,
+            PyTileCategory::Simples => TileCategory::Simples,
+            PyTileCategory::Honors => TileCategory::Honors,
+        }
+    }
+}
+
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum PyTileName {
+    None = 0,
+    OneM,
+    TwoM,
+    ThreeM,
+    FourM,
+    FiveM,
+    SixM,
+    SevenM,
+    EightM,
+    NineM,
+    OneP,
+    TwoP,
+    ThreeP,
+    FourP,
+    FiveP,
+    SixP,
+    SevenP,
+    EightP,
+    NineP,
+    OneS,
+    TwoS,
+    ThreeS,
+    FourS,
+    FiveS,
+    SixS,
+    SevenS,
+    EightS,
+    NineS,
+    East,
+    South,
+    West,
+    North,
+    Red,
+    Green,
+    White,
+}
+
+impl From<TileName> for PyTileName {
+    fn from(t: TileName) -> Self {
+        match t {
+            TileName::None => PyTileName::None,
+            TileName::OneM => PyTileName::OneM,
+            TileName::TwoM => PyTileName::TwoM,
+            TileName::ThreeM => PyTileName::ThreeM,
+            TileName::FourM => PyTileName::FourM,
+            TileName::FiveM => PyTileName::FiveM,
+            TileName::SixM => PyTileName::SixM,
+            TileName::SevenM => PyTileName::SevenM,
+            TileName::EightM => PyTileName::EightM,
+            TileName::NineM => PyTileName::NineM,
+            TileName::OneP => PyTileName::OneP,
+            TileName::TwoP => PyTileName::TwoP,
+            TileName::ThreeP => PyTileName::ThreeP,
+            TileName::FourP => PyTileName::FourP,
+            TileName::FiveP => PyTileName::FiveP,
+            TileName::SixP => PyTileName::SixP,
+            TileName::SevenP => PyTileName::SevenP,
+            TileName::EightP => PyTileName::EightP,
+            TileName::NineP => PyTileName::NineP,
+            TileName::OneS => PyTileName::OneS,
+            TileName::TwoS => PyTileName::TwoS,
+            TileName::ThreeS => PyTileName::ThreeS,
+            TileName::FourS => PyTileName::FourS,
+            TileName::FiveS => PyTileName::FiveS,
+            TileName::SixS => PyTileName::SixS,
+            TileName::SevenS => PyTileName::SevenS,
+            TileName::EightS => PyTileName::EightS,
+            TileName::NineS => PyTileName::NineS,
+            TileName::East => PyTileName::East,
+            TileName::South => PyTileName::South,
+            TileName::West => PyTileName::West,
+            TileName::North => PyTileName::North,
+            TileName::Red => PyTileName::Red,
+            TileName::Green => PyTileName::Green,
+            TileName::White => PyTileName::White,
+        }
+    }
+}
+
+impl Into<TileName> for PyTileName {
+    fn into(self) -> TileName {
+        match self {
+            PyTileName::None => TileName::None,
+            PyTileName::OneM => TileName::OneM,
+            PyTileName::TwoM => TileName::TwoM,
+            PyTileName::ThreeM => TileName::ThreeM,
+            PyTileName::FourM => TileName::FourM,
+            PyTileName::FiveM => TileName::FiveM,
+            PyTileName::SixM => TileName::SixM,
+            PyTileName::SevenM => TileName::SevenM,
+            PyTileName::EightM => TileName::EightM,
+            PyTileName::NineM => TileName::NineM,
+            PyTileName::OneP => TileName::OneP,
+            PyTileName::TwoP => TileName::TwoP,
+            PyTileName::ThreeP => TileName::ThreeP,
+            PyTileName::FourP => TileName::FourP,
+            PyTileName::FiveP => TileName::FiveP,
+            PyTileName::SixP => TileName::SixP,
+            PyTileName::SevenP => TileName::SevenP,
+            PyTileName::EightP => TileName::EightP,
+            PyTileName::NineP => TileName::NineP,
+            PyTileName::OneS => TileName::OneS,
+            PyTileName::TwoS => TileName::TwoS,
+            PyTileName::ThreeS => TileName::ThreeS,
+            PyTileName::FourS => TileName::FourS,
+            PyTileName::FiveS => TileName::FiveS,
+            PyTileName::SixS => TileName::SixS,
+            PyTileName::SevenS => TileName::SevenS,
+            PyTileName::EightS => TileName::EightS,
+            PyTileName::NineS => TileName::NineS,
+            PyTileName::East => TileName::East,
+            PyTileName::South => TileName::South,
+            PyTileName::West => TileName::West,
+            PyTileName::North => TileName::North,
+            PyTileName::Red => TileName::Red,
+            PyTileName::Green => TileName::Green,
+            PyTileName::White => TileName::White,
+        }
+    }
+}
+
+#[pymethods]
+impl PyTileName {
+    pub fn as_str(&self) -> &'static str {
+        let t: TileName = (*self).into();
+        t.as_str()
+    }
+
+    pub fn tile_type(&self) -> PyTileType {
+        let t: TileName = (*self).into();
+        t.tile_type().into()
+    }
+
+    pub fn category(&self) -> PyTileCategory {
+        let t: TileName = (*self).into();
+        t.category().into()
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyTile {
+    tile: Tile,
+}
+
+#[pymethods]
+impl PyTile {
+    #[new]
+    pub fn new(name: PyTileName) -> Self {
+        Self {
+            tile: Tile::new(name.into()),
+        }
+    }
+
+    #[getter]
+    pub fn name(&self) -> PyTileName {
+        self.tile.name().into()
+    }
+
+    #[getter]
+    pub fn tile_type(&self) -> PyTileType {
+        self.tile.tile_type().into()
+    }
+
+    #[getter]
+    pub fn category(&self) -> PyTileCategory {
+        self.tile.category().into()
+    }
+}
+
+// ==========================================
+// 2. Meld and Hand wrappers
+// ==========================================
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyMeld {
+    meld: Meld,
+}
+
+impl From<Meld> for PyMeld {
+    fn from(m: Meld) -> Self {
+        Self { meld: m }
+    }
+}
+
+impl Into<Meld> for PyMeld {
+    fn into(self) -> Meld {
+        self.meld
+    }
+}
+
+#[pymethods]
+impl PyMeld {
+    #[staticmethod]
+    pub fn chii(called: PyTileName, consumed: [PyTileName; 2]) -> Self {
+        Self {
+            meld: Meld::Chii {
+                called: called.into(),
+                consumed: [consumed[0].into(), consumed[1].into()],
+            },
+        }
+    }
+
+    #[staticmethod]
+    pub fn pon(tile: PyTileName) -> Self {
+        Self {
+            meld: Meld::Pon(tile.into()),
+        }
+    }
+
+    #[staticmethod]
+    pub fn daiminkan(tile: PyTileName) -> Self {
+        Self {
+            meld: Meld::Daiminkan(tile.into()),
+        }
+    }
+
+    #[staticmethod]
+    pub fn ankan(tile: PyTileName) -> Self {
+        Self {
+            meld: Meld::Ankan(tile.into()),
+        }
+    }
+
+    #[staticmethod]
+    pub fn kakan(tile: PyTileName) -> Self {
+        Self {
+            meld: Meld::Kakan(tile.into()),
+        }
+    }
+
+    #[getter]
+    pub fn kind(&self) -> String {
+        match self.meld {
+            Meld::Chii { .. } => "chii".to_string(),
+            Meld::Pon(_) => "pon".to_string(),
+            Meld::Daiminkan(_) => "daiminkan".to_string(),
+            Meld::Ankan(_) => "ankan".to_string(),
+            Meld::Kakan(_) => "kakan".to_string(),
+        }
+    }
+
+    #[getter]
+    pub fn tiles(&self) -> Vec<PyTileName> {
+        match self.meld {
+            Meld::Chii { called, consumed } => {
+                vec![called.into(), consumed[0].into(), consumed[1].into()]
+            }
+            Meld::Pon(t) => vec![t.into(), t.into(), t.into()],
+            Meld::Daiminkan(t) => vec![t.into(), t.into(), t.into(), t.into()],
+            Meld::Ankan(t) => vec![t.into(), t.into(), t.into(), t.into()],
+            Meld::Kakan(t) => vec![t.into(), t.into(), t.into(), t.into()],
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyHand {
+    pub(crate) hand: Hand,
+}
+
+#[pymethods]
+impl PyHand {
+    #[new]
+    pub fn new() -> Self {
+        Self { hand: Hand::new() }
+    }
+
+    #[getter]
+    pub fn tiles(&self) -> Vec<PyTileName> {
+        self.hand.tiles().iter().map(|&t| t.into()).collect()
+    }
+
+    #[getter]
+    pub fn open_melds(&self) -> Vec<PyMeld> {
+        self.hand.open_melds.iter().map(|&m| m.into()).collect()
+    }
+
+    pub fn push(&mut self, tile: PyTileName) {
+        self.hand.push(tile.into());
+    }
+
+    pub fn discard(&mut self, index: usize) -> PyResult<PyTileName> {
+        match self.hand.discard(index) {
+            Ok(t) => Ok(t.into()),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
+    }
+
+    pub fn call_meld(&mut self, meld: PyMeld) -> PyResult<()> {
+        match self.hand.call_meld(meld.into()) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
+    }
+}
+
+// ==========================================
+// 3. River, Wall, and Round wrappers
+// ==========================================
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyRiver {
+    pub(crate) river: River,
+}
+
+#[pymethods]
+impl PyRiver {
+    #[new]
+    pub fn new() -> Self {
+        Self {
+            river: River::new(),
+        }
+    }
+
+    #[getter]
+    pub fn tiles(&self) -> Vec<PyTileName> {
+        self.river.tiles().iter().map(|&t| t.into()).collect()
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyWall {
+    pub(crate) wall: Wall,
+}
+
+#[pymethods]
+impl PyWall {
+    #[new]
+    pub fn new() -> Self {
+        Self { wall: Wall::new() }
+    }
+
+    pub fn shuffle(&mut self, seed: u64) {
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+        let mut rng = StdRng::seed_from_u64(seed);
+        self.wall.shuffle(&mut rng);
+    }
+
+    pub fn draw(&mut self) -> Option<PyTileName> {
+        self.wall.draw().map(|t| t.into())
+    }
+
+    pub fn draw_replacement(&mut self) -> Option<PyTileName> {
+        self.wall.draw_replacement().map(|t| t.into())
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.wall.remaining()
+    }
+}
+
+#[pyclass]
+#[derive(Debug)]
+pub struct PyRound {
+    round: Round,
+}
+
+#[pymethods]
+impl PyRound {
+    #[new]
+    pub fn new(wall: &PyWall) -> Self {
+        Self {
+            round: Round::new(wall.wall.clone()),
+        }
+    }
+
+    pub fn turn(&self) -> usize {
+        self.round.turn()
+    }
+
+    pub fn hand(&self, index: usize) -> Vec<PyTileName> {
+        self.round.hand(index).iter().map(|&t| t.into()).collect()
+    }
+
+    pub fn river(&self, index: usize) -> PyRiver {
+        PyRiver {
+            river: self.round.river(index).clone(),
+        }
+    }
+
+    pub fn draw_tile(&mut self) -> Option<PyTileName> {
+        self.round.draw_tile().map(|t| t.into())
+    }
+
+    pub fn discard_tile(&mut self, index: usize) -> PyResult<PyTileName> {
+        match self.round.discard_tile(index) {
+            Ok(t) => Ok(t.into()),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
+    }
+
+    pub fn play_meld(&mut self, player_index: usize, meld: &PyMeld) -> PyResult<()> {
+        match self.round.play_meld(player_index, meld.clone().into()) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
+    }
+}
+
+// ==========================================
+// 4. Yaku and Yaku judgement wrappers
+// ==========================================
+
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum PyYakuId {
+    Riichi,
+    MenzenTsumo,
+    Tanyao,
+    Pinfu,
+    Ipeiko,
+    YakuhaiHaku,
+    YakuhaiHatsu,
+    YakuhaiChun,
+    YakuhaiJikaze,
+    YakuhaiBakaze,
+    Chitoitsu,
+    Toitoi,
+    Sanankou,
+    Shousangen,
+    Chantaiyao,
+    Ryanpeiko,
+    SanshokuDoujun,
+    SanshokuDoukou,
+    Honitsu,
+    Junchan,
+    Chinitsu,
+    Chinroutou,
+    Honroutou,
+    Sankantsu,
+    KokushiMusou,
+    Suuankou,
+    Daisangen,
+    Shousuushi,
+    Daisuushi,
+    Suukantsu,
+    Tsuuiisou,
+    Ryuuiisou,
+    ChuurenPoutou,
+    Tenhou,
+    Chiihou,
+    RinshanKaihou,
+    Chankan,
+    HaiteiRaoyue,
+    HouteiRaoyui,
+    DoubleRiichi,
+    Ippatsu,
+}
+
+impl From<YakuId> for PyYakuId {
+    fn from(y: YakuId) -> Self {
+        match y {
+            YakuId::Riichi => PyYakuId::Riichi,
+            YakuId::MenzenTsumo => PyYakuId::MenzenTsumo,
+            YakuId::Tanyao => PyYakuId::Tanyao,
+            YakuId::Pinfu => PyYakuId::Pinfu,
+            YakuId::Ipeiko => PyYakuId::Ipeiko,
+            YakuId::YakuhaiHaku => PyYakuId::YakuhaiHaku,
+            YakuId::YakuhaiHatsu => PyYakuId::YakuhaiHatsu,
+            YakuId::YakuhaiChun => PyYakuId::YakuhaiChun,
+            YakuId::YakuhaiJikaze => PyYakuId::YakuhaiJikaze,
+            YakuId::YakuhaiBakaze => PyYakuId::YakuhaiBakaze,
+            YakuId::Chitoitsu => PyYakuId::Chitoitsu,
+            YakuId::Toitoi => PyYakuId::Toitoi,
+            YakuId::Sanankou => PyYakuId::Sanankou,
+            YakuId::Shousangen => PyYakuId::Shousangen,
+            YakuId::Chantaiyao => PyYakuId::Chantaiyao,
+            YakuId::Ryanpeiko => PyYakuId::Ryanpeiko,
+            YakuId::SanshokuDoujun => PyYakuId::SanshokuDoujun,
+            YakuId::SanshokuDoukou => PyYakuId::SanshokuDoukou,
+            YakuId::Honitsu => PyYakuId::Honitsu,
+            YakuId::Junchan => PyYakuId::Junchan,
+            YakuId::Chinitsu => PyYakuId::Chinitsu,
+            YakuId::Chinroutou => PyYakuId::Chinroutou,
+            YakuId::Honroutou => PyYakuId::Honroutou,
+            YakuId::Sankantsu => PyYakuId::Sankantsu,
+            YakuId::KokushiMusou => PyYakuId::KokushiMusou,
+            YakuId::Suuankou => PyYakuId::Suuankou,
+            YakuId::Daisangen => PyYakuId::Daisangen,
+            YakuId::Shousuushi => PyYakuId::Shousuushi,
+            YakuId::Daisuushi => PyYakuId::Daisuushi,
+            YakuId::Suukantsu => PyYakuId::Suukantsu,
+            YakuId::Tsuuiisou => PyYakuId::Tsuuiisou,
+            YakuId::Ryuuiisou => PyYakuId::Ryuuiisou,
+            YakuId::ChuurenPoutou => PyYakuId::ChuurenPoutou,
+            YakuId::Tenhou => PyYakuId::Tenhou,
+            YakuId::Chiihou => PyYakuId::Chiihou,
+            YakuId::RinshanKaihou => PyYakuId::RinshanKaihou,
+            YakuId::Chankan => PyYakuId::Chankan,
+            YakuId::HaiteiRaoyue => PyYakuId::HaiteiRaoyue,
+            YakuId::HouteiRaoyui => PyYakuId::HouteiRaoyui,
+            YakuId::DoubleRiichi => PyYakuId::DoubleRiichi,
+            YakuId::Ippatsu => PyYakuId::Ippatsu,
+        }
+    }
+}
+
+impl Into<YakuId> for PyYakuId {
+    fn into(self) -> YakuId {
+        match self {
+            PyYakuId::Riichi => YakuId::Riichi,
+            PyYakuId::MenzenTsumo => YakuId::MenzenTsumo,
+            PyYakuId::Tanyao => YakuId::Tanyao,
+            PyYakuId::Pinfu => YakuId::Pinfu,
+            PyYakuId::Ipeiko => YakuId::Ipeiko,
+            PyYakuId::YakuhaiHaku => YakuId::YakuhaiHaku,
+            PyYakuId::YakuhaiHatsu => YakuId::YakuhaiHatsu,
+            PyYakuId::YakuhaiChun => YakuId::YakuhaiChun,
+            PyYakuId::YakuhaiJikaze => YakuId::YakuhaiJikaze,
+            PyYakuId::YakuhaiBakaze => YakuId::YakuhaiBakaze,
+            PyYakuId::Chitoitsu => YakuId::Chitoitsu,
+            PyYakuId::Toitoi => YakuId::Toitoi,
+            PyYakuId::Sanankou => YakuId::Sanankou,
+            PyYakuId::Shousangen => YakuId::Shousangen,
+            PyYakuId::Chantaiyao => YakuId::Chantaiyao,
+            PyYakuId::Ryanpeiko => YakuId::Ryanpeiko,
+            PyYakuId::SanshokuDoujun => YakuId::SanshokuDoujun,
+            PyYakuId::SanshokuDoukou => YakuId::SanshokuDoukou,
+            PyYakuId::Honitsu => YakuId::Honitsu,
+            PyYakuId::Junchan => YakuId::Junchan,
+            PyYakuId::Chinitsu => YakuId::Chinitsu,
+            PyYakuId::Chinroutou => YakuId::Chinroutou,
+            PyYakuId::Honroutou => YakuId::Honroutou,
+            PyYakuId::Sankantsu => YakuId::Sankantsu,
+            PyYakuId::KokushiMusou => YakuId::KokushiMusou,
+            PyYakuId::Suuankou => YakuId::Suuankou,
+            PyYakuId::Daisangen => YakuId::Daisangen,
+            PyYakuId::Shousuushi => YakuId::Shousuushi,
+            PyYakuId::Daisuushi => YakuId::Daisuushi,
+            PyYakuId::Suukantsu => YakuId::Suukantsu,
+            PyYakuId::Tsuuiisou => YakuId::Tsuuiisou,
+            PyYakuId::Ryuuiisou => YakuId::Ryuuiisou,
+            PyYakuId::ChuurenPoutou => YakuId::ChuurenPoutou,
+            PyYakuId::Tenhou => YakuId::Tenhou,
+            PyYakuId::Chiihou => YakuId::Chiihou,
+            PyYakuId::RinshanKaihou => YakuId::RinshanKaihou,
+            PyYakuId::Chankan => YakuId::Chankan,
+            PyYakuId::HaiteiRaoyue => YakuId::HaiteiRaoyue,
+            PyYakuId::HouteiRaoyui => YakuId::HouteiRaoyui,
+            PyYakuId::DoubleRiichi => YakuId::DoubleRiichi,
+            PyYakuId::Ippatsu => YakuId::Ippatsu,
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyYaku {
+    yaku: Yaku,
+}
+
+impl From<Yaku> for PyYaku {
+    fn from(y: Yaku) -> Self {
+        Self { yaku: y }
+    }
+}
+
+#[pymethods]
+impl PyYaku {
+    #[getter]
+    pub fn id(&self) -> PyYakuId {
+        self.yaku.id.into()
+    }
+
+    #[getter]
+    pub fn name_ja(&self) -> String {
+        self.yaku.name_ja.to_string()
+    }
+
+    #[getter]
+    pub fn name_kana(&self) -> String {
+        self.yaku.name_kana.to_string()
+    }
+
+    #[getter]
+    pub fn han_closed(&self) -> i8 {
+        self.yaku.han_closed
+    }
+
+    #[getter]
+    pub fn han_open(&self) -> i8 {
+        self.yaku.han_open
+    }
+
+    #[getter]
+    pub fn yakuman(&self) -> bool {
+        self.yaku.yakuman
+    }
+}
+
+#[pyfunction]
+pub fn get_all_yaku() -> Vec<PyYaku> {
+    ALL_YAKU.iter().map(|y| (*y).into()).collect()
+}
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct PyWinContext {
+    #[pyo3(get, set)]
+    pub is_closed: bool,
+    #[pyo3(get, set)]
+    pub is_tsumo: bool,
+    #[pyo3(get, set)]
+    pub seat_wind: Option<PyTileName>,
+    #[pyo3(get, set)]
+    pub round_wind: Option<PyTileName>,
+    #[pyo3(get, set)]
+    pub riichi: bool,
+    #[pyo3(get, set)]
+    pub kan_count: usize,
+    #[pyo3(get, set)]
+    pub tenhou: bool,
+    #[pyo3(get, set)]
+    pub chiihou: bool,
+    #[pyo3(get, set)]
+    pub win_tile: Option<PyTileName>,
+    #[pyo3(get, set)]
+    pub is_rinshan: bool,
+    #[pyo3(get, set)]
+    pub is_chankan: bool,
+    #[pyo3(get, set)]
+    pub is_haitei: bool,
+    #[pyo3(get, set)]
+    pub is_houtei: bool,
+    #[pyo3(get, set)]
+    pub is_double_riichi: bool,
+    #[pyo3(get, set)]
+    pub is_ippatsu: bool,
+}
+
+#[pymethods]
+impl PyWinContext {
+    #[new]
+    #[pyo3(signature = (is_closed=true, is_tsumo=true, seat_wind=None, round_wind=None, riichi=false, kan_count=0, tenhou=false, chiihou=false, win_tile=None, is_rinshan=false, is_chankan=false, is_haitei=false, is_houtei=false, is_double_riichi=false, is_ippatsu=false))]
+    pub fn new(
+        is_closed: bool,
+        is_tsumo: bool,
+        seat_wind: Option<PyTileName>,
+        round_wind: Option<PyTileName>,
+        riichi: bool,
+        kan_count: usize,
+        tenhou: bool,
+        chiihou: bool,
+        win_tile: Option<PyTileName>,
+        is_rinshan: bool,
+        is_chankan: bool,
+        is_haitei: bool,
+        is_houtei: bool,
+        is_double_riichi: bool,
+        is_ippatsu: bool,
+    ) -> Self {
+        Self {
+            is_closed,
+            is_tsumo,
+            seat_wind,
+            round_wind,
+            riichi,
+            kan_count,
+            tenhou,
+            chiihou,
+            win_tile,
+            is_rinshan,
+            is_chankan,
+            is_haitei,
+            is_houtei,
+            is_double_riichi,
+            is_ippatsu,
+        }
+    }
+}
+
+impl Into<WinContext> for PyWinContext {
+    fn into(self) -> WinContext {
+        WinContext {
+            is_closed: self.is_closed,
+            is_tsumo: self.is_tsumo,
+            seat_wind: self.seat_wind.map(|t| t.into()),
+            round_wind: self.round_wind.map(|t| t.into()),
+            riichi: self.riichi,
+            kan_count: self.kan_count,
+            tenhou: self.tenhou,
+            chiihou: self.chiihou,
+            win_tile: self.win_tile.map(|t| t.into()),
+            is_rinshan: self.is_rinshan,
+            is_chankan: self.is_chankan,
+            is_haitei: self.is_haitei,
+            is_houtei: self.is_houtei,
+            is_double_riichi: self.is_double_riichi,
+            is_ippatsu: self.is_ippatsu,
+        }
+    }
+}
+
+#[pyfunction]
+pub fn py_judge_yaku(
+    tiles: Vec<PyTileName>,
+    melds: Vec<PyMeld>,
+    context: PyWinContext,
+) -> Vec<PyYakuId> {
+    let rs_tiles: Vec<TileName> = tiles.into_iter().map(|t| t.into()).collect();
+    let rs_melds: Vec<Meld> = melds.into_iter().map(|m| m.into()).collect();
+    let rs_context: WinContext = context.into();
+
+    let result = judge_yaku(&rs_tiles, &rs_melds, rs_context);
+    result.into_iter().map(|y| y.into()).collect()
+}

--- a/src/python_api.rs
+++ b/src/python_api.rs
@@ -36,9 +36,9 @@ impl From<TileType> for PyTileType {
     }
 }
 
-impl Into<TileType> for PyTileType {
-    fn into(self) -> TileType {
-        match self {
+impl From<PyTileType> for TileType {
+    fn from(val: PyTileType) -> Self {
+        match val {
             PyTileType::None => TileType::None,
             PyTileType::Characters => TileType::Characters,
             PyTileType::Circles => TileType::Circles,
@@ -67,9 +67,9 @@ impl From<TileCategory> for PyTileCategory {
     }
 }
 
-impl Into<TileCategory> for PyTileCategory {
-    fn into(self) -> TileCategory {
-        match self {
+impl From<PyTileCategory> for TileCategory {
+    fn from(val: PyTileCategory) -> Self {
+        match val {
             PyTileCategory::None => TileCategory::None,
             PyTileCategory::Simples => TileCategory::Simples,
             PyTileCategory::Honors => TileCategory::Honors,
@@ -159,9 +159,9 @@ impl From<TileName> for PyTileName {
     }
 }
 
-impl Into<TileName> for PyTileName {
-    fn into(self) -> TileName {
-        match self {
+impl From<PyTileName> for TileName {
+    fn from(val: PyTileName) -> Self {
+        match val {
             PyTileName::None => TileName::None,
             PyTileName::OneM => TileName::OneM,
             PyTileName::TwoM => TileName::TwoM,
@@ -228,6 +228,7 @@ pub struct PyTile {
 #[pymethods]
 impl PyTile {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(name: PyTileName) -> Self {
         Self {
             tile: Tile::new(name.into()),
@@ -266,9 +267,9 @@ impl From<Meld> for PyMeld {
     }
 }
 
-impl Into<Meld> for PyMeld {
-    fn into(self) -> Meld {
-        self.meld
+impl From<PyMeld> for Meld {
+    fn from(val: PyMeld) -> Self {
+        val.meld
     }
 }
 
@@ -338,7 +339,7 @@ impl PyMeld {
 }
 
 #[pyclass]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PyHand {
     pub(crate) hand: Hand,
 }
@@ -346,6 +347,7 @@ pub struct PyHand {
 #[pymethods]
 impl PyHand {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     pub fn new() -> Self {
         Self { hand: Hand::new() }
     }
@@ -384,7 +386,7 @@ impl PyHand {
 // ==========================================
 
 #[pyclass]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PyRiver {
     pub(crate) river: River,
 }
@@ -392,6 +394,7 @@ pub struct PyRiver {
 #[pymethods]
 impl PyRiver {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     pub fn new() -> Self {
         Self {
             river: River::new(),
@@ -405,7 +408,7 @@ impl PyRiver {
 }
 
 #[pyclass]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PyWall {
     pub(crate) wall: Wall,
 }
@@ -413,6 +416,7 @@ pub struct PyWall {
 #[pymethods]
 impl PyWall {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     pub fn new() -> Self {
         Self { wall: Wall::new() }
     }
@@ -446,6 +450,7 @@ pub struct PyRound {
 #[pymethods]
 impl PyRound {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(wall: &PyWall) -> Self {
         Self {
             round: Round::new(wall.wall.clone()),
@@ -583,9 +588,9 @@ impl From<YakuId> for PyYakuId {
     }
 }
 
-impl Into<YakuId> for PyYakuId {
-    fn into(self) -> YakuId {
-        match self {
+impl From<PyYakuId> for YakuId {
+    fn from(val: PyYakuId) -> Self {
+        match val {
             PyYakuId::Riichi => YakuId::Riichi,
             PyYakuId::MenzenTsumo => YakuId::MenzenTsumo,
             PyYakuId::Tanyao => YakuId::Tanyao,
@@ -719,6 +724,7 @@ pub struct PyWinContext {
 #[pymethods]
 impl PyWinContext {
     #[new]
+    #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (is_closed=true, is_tsumo=true, seat_wind=None, round_wind=None, riichi=false, kan_count=0, tenhou=false, chiihou=false, win_tile=None, is_rinshan=false, is_chankan=false, is_haitei=false, is_houtei=false, is_double_riichi=false, is_ippatsu=false))]
     pub fn new(
         is_closed: bool,
@@ -757,24 +763,24 @@ impl PyWinContext {
     }
 }
 
-impl Into<WinContext> for PyWinContext {
-    fn into(self) -> WinContext {
+impl From<PyWinContext> for WinContext {
+    fn from(val: PyWinContext) -> Self {
         WinContext {
-            is_closed: self.is_closed,
-            is_tsumo: self.is_tsumo,
-            seat_wind: self.seat_wind.map(|t| t.into()),
-            round_wind: self.round_wind.map(|t| t.into()),
-            riichi: self.riichi,
-            kan_count: self.kan_count,
-            tenhou: self.tenhou,
-            chiihou: self.chiihou,
-            win_tile: self.win_tile.map(|t| t.into()),
-            is_rinshan: self.is_rinshan,
-            is_chankan: self.is_chankan,
-            is_haitei: self.is_haitei,
-            is_houtei: self.is_houtei,
-            is_double_riichi: self.is_double_riichi,
-            is_ippatsu: self.is_ippatsu,
+            is_closed: val.is_closed,
+            is_tsumo: val.is_tsumo,
+            seat_wind: val.seat_wind.map(|t| t.into()),
+            round_wind: val.round_wind.map(|t| t.into()),
+            riichi: val.riichi,
+            kan_count: val.kan_count,
+            tenhou: val.tenhou,
+            chiihou: val.chiihou,
+            win_tile: val.win_tile.map(|t| t.into()),
+            is_rinshan: val.is_rinshan,
+            is_chankan: val.is_chankan,
+            is_haitei: val.is_haitei,
+            is_houtei: val.is_houtei,
+            is_double_riichi: val.is_double_riichi,
+            is_ippatsu: val.is_ippatsu,
         }
     }
 }

--- a/tests/test_round.rs
+++ b/tests/test_round.rs
@@ -180,7 +180,7 @@ mod tests {
             for &t in p0_hand {
                 counts[t as usize] += 1;
             }
-            if counts.iter().any(|&c| c == 4) {
+            if counts.contains(&4) {
                 let tile_idx = counts.iter().position(|&c| c == 4).unwrap();
                 found_ankan = Some((seed, TileName::from_usize(tile_idx)));
                 break;

--- a/tests/test_wall.rs
+++ b/tests/test_wall.rs
@@ -1,5 +1,4 @@
 #[cfg(test)]
-
 mod tests {
     use std::collections::HashMap;
 

--- a/tests/test_yaku.rs
+++ b/tests/test_yaku.rs
@@ -508,9 +508,11 @@ mod tests_kan {
             White,
         ];
         // Ensure that normal yaku are filtered out when Yakuman is achieved.
-        let mut ctx = WinContext::default();
-        ctx.riichi = true;
-        ctx.is_closed = true;
+        let ctx = WinContext {
+            riichi: true,
+            is_closed: true,
+            ..WinContext::default()
+        };
 
         let result = judge_yaku(&tiles, &[], ctx);
 

--- a/tests/test_yaku_context.rs
+++ b/tests/test_yaku_context.rs
@@ -24,9 +24,11 @@ fn create_valid_hand() -> Vec<TileName> {
 #[test]
 fn test_rinshan_kaihou() {
     let tiles = create_valid_hand();
-    let mut ctx = WinContext::default();
-    ctx.is_tsumo = true;
-    ctx.is_rinshan = true;
+    let ctx = WinContext {
+        is_tsumo: true,
+        is_rinshan: true,
+        ..WinContext::default()
+    };
 
     let yaku = judge_yaku(&tiles, &[], ctx);
     assert!(yaku.contains(&YakuId::RinshanKaihou));
@@ -35,9 +37,11 @@ fn test_rinshan_kaihou() {
 #[test]
 fn test_chankan() {
     let tiles = create_valid_hand();
-    let mut ctx = WinContext::default();
-    ctx.is_tsumo = false;
-    ctx.is_chankan = true;
+    let ctx = WinContext {
+        is_tsumo: false,
+        is_chankan: true,
+        ..WinContext::default()
+    };
 
     let yaku = judge_yaku(&tiles, &[], ctx);
     assert!(yaku.contains(&YakuId::Chankan));
@@ -46,9 +50,11 @@ fn test_chankan() {
 #[test]
 fn test_haitei_raoyue() {
     let tiles = create_valid_hand();
-    let mut ctx = WinContext::default();
-    ctx.is_tsumo = true;
-    ctx.is_haitei = true;
+    let ctx = WinContext {
+        is_tsumo: true,
+        is_haitei: true,
+        ..WinContext::default()
+    };
 
     let yaku = judge_yaku(&tiles, &[], ctx);
     assert!(yaku.contains(&YakuId::HaiteiRaoyue));
@@ -57,9 +63,11 @@ fn test_haitei_raoyue() {
 #[test]
 fn test_houtei_raoyui() {
     let tiles = create_valid_hand();
-    let mut ctx = WinContext::default();
-    ctx.is_tsumo = false;
-    ctx.is_houtei = true;
+    let ctx = WinContext {
+        is_tsumo: false,
+        is_houtei: true,
+        ..WinContext::default()
+    };
 
     let yaku = judge_yaku(&tiles, &[], ctx);
     assert!(yaku.contains(&YakuId::HouteiRaoyui));
@@ -68,10 +76,12 @@ fn test_houtei_raoyui() {
 #[test]
 fn test_double_riichi_and_ippatsu() {
     let tiles = create_valid_hand();
-    let mut ctx = WinContext::default();
-    ctx.is_double_riichi = true;
-    ctx.is_ippatsu = true;
-    ctx.is_closed = true;
+    let ctx = WinContext {
+        is_double_riichi: true,
+        is_ippatsu: true,
+        is_closed: true,
+        ..WinContext::default()
+    };
 
     let yaku = judge_yaku(&tiles, &[], ctx);
     assert!(yaku.contains(&YakuId::DoubleRiichi));
@@ -82,10 +92,12 @@ fn test_double_riichi_and_ippatsu() {
 #[test]
 fn test_ippatsu_with_normal_riichi() {
     let tiles = create_valid_hand();
-    let mut ctx = WinContext::default();
-    ctx.riichi = true;
-    ctx.is_ippatsu = true;
-    ctx.is_closed = true;
+    let ctx = WinContext {
+        riichi: true,
+        is_ippatsu: true,
+        is_closed: true,
+        ..WinContext::default()
+    };
 
     let yaku = judge_yaku(&tiles, &[], ctx);
     assert!(yaku.contains(&YakuId::Riichi));

--- a/tests/test_yaku_open_melds.rs
+++ b/tests/test_yaku_open_melds.rs
@@ -22,8 +22,10 @@ fn test_yaku_open_melds() {
     // Meld: Pon of White Dragon
     let melds = vec![Meld::Pon(TileName::White)];
 
-    let mut ctx = WinContext::default();
-    ctx.is_closed = false;
+    let ctx = WinContext {
+        is_closed: false,
+        ..WinContext::default()
+    };
 
     let result = judge_yaku(&tiles, &melds, ctx);
     assert!(result.contains(&YakuId::YakuhaiHaku));

--- a/tests_python/test_mahjong.py
+++ b/tests_python/test_mahjong.py
@@ -1,0 +1,89 @@
+import pytest
+import mahjong
+
+def test_tile_bindings():
+    # Test PyTileName Enum and its methods
+    t_name = mahjong.PyTileName.East
+    assert t_name.as_str() == "東"
+    assert t_name.tile_type() == mahjong.PyTileType.Winds
+    assert t_name.category() == mahjong.PyTileCategory.Honors
+
+    # Test PyTile Wrapper
+    tile = mahjong.PyTile(t_name)
+    assert tile.name == mahjong.PyTileName.East
+    assert tile.tile_type == mahjong.PyTileType.Winds
+    assert tile.category == mahjong.PyTileCategory.Honors
+
+def test_hand_melds():
+    hand = mahjong.PyHand()
+
+    # Push tiles
+    hand.push(mahjong.PyTileName.OneM)
+    hand.push(mahjong.PyTileName.TwoM)
+    hand.push(mahjong.PyTileName.ThreeM)
+    hand.push(mahjong.PyTileName.East)
+    hand.push(mahjong.PyTileName.East)
+
+    tiles = hand.tiles
+    assert len(tiles) == 5
+    assert tiles[0] == mahjong.PyTileName.OneM
+
+    # Call meld (Pon)
+    # To call a Pon on East, we should have two Easts in hand. We do.
+    # Oh wait, hand.call_meld consumes from hand if the tiles exist. Let's see.
+    pon_meld = mahjong.PyMeld.pon(mahjong.PyTileName.East)
+    hand.call_meld(pon_meld)
+
+    assert len(hand.tiles) == 3
+    assert len(hand.open_melds) == 1
+    assert hand.open_melds[0].kind == "pon"
+
+def test_round_wall():
+    wall = mahjong.PyWall()
+    wall.shuffle(42)
+
+    assert wall.remaining() == 136 - 14
+
+    round_obj = mahjong.PyRound(wall)
+    assert round_obj.turn() == 0
+    assert len(round_obj.hand(0)) == 13
+
+    # Draw tile
+    drawn = round_obj.draw_tile()
+    assert drawn is not None
+    assert len(round_obj.hand(0)) == 14
+
+    # Discard tile
+    discarded = round_obj.discard_tile(0)
+    assert discarded is not None
+    assert len(round_obj.hand(0)) == 13
+    assert round_obj.turn() == 1
+
+def test_judge_yaku():
+    # Tsumo, Closed, Seat East, Round East
+    ctx = mahjong.PyWinContext(
+        is_closed=True,
+        is_tsumo=True,
+        seat_wind=mahjong.PyTileName.East,
+        round_wind=mahjong.PyTileName.East, win_tile=mahjong.PyTileName.FourM,
+    )
+
+    # Chinitsu + Tanyao (1s 1s 1s 2s 3s 4s 5s 6s 7s 8s 9s 9s 9s) -> Chinitsu, Chuuren Poutou...
+    # Let's just do a simple Riichi Menzen Tsumo Tanyao
+    # 2m 3m 4m, 3p 4p 5p, 4s 5s 6s, 6s 7s 8s, 2p 2p
+    tiles = [
+        mahjong.PyTileName.TwoM, mahjong.PyTileName.ThreeM, mahjong.PyTileName.FourM,
+        mahjong.PyTileName.ThreeP, mahjong.PyTileName.FourP, mahjong.PyTileName.FiveP,
+        mahjong.PyTileName.FourS, mahjong.PyTileName.FiveS, mahjong.PyTileName.SixS,
+        mahjong.PyTileName.SixS, mahjong.PyTileName.SevenS, mahjong.PyTileName.EightS,
+        mahjong.PyTileName.TwoP, mahjong.PyTileName.TwoP,
+    ]
+    melds = []
+
+    ctx.riichi = True
+
+    yaku_ids = mahjong.py_judge_yaku(tiles, melds, ctx)
+    assert mahjong.PyYakuId.Riichi in yaku_ids
+    assert mahjong.PyYakuId.MenzenTsumo in yaku_ids
+    assert mahjong.PyYakuId.Tanyao in yaku_ids
+    assert mahjong.PyYakuId.Pinfu in yaku_ids # All sequences + non-yakuhai pair + 2-sided wait


### PR DESCRIPTION
I have created a dedicated `src/python_api.rs` module that contains all the PyO3 bindings for the Mahjong project using a wrapper pattern. It exposes classes for Tiles (`PyTileType`, `PyTileCategory`, `PyTileName`, `PyTile`), Hands/Melds (`PyMeld`, `PyHand`), Walls/Rounds (`PyWall`, `PyRiver`, `PyRound`), and Yaku judgement (`PyWinContext`, `PyYakuId`, `PyYaku`, `get_all_yaku`, `py_judge_yaku`). 

I also updated `src/lib.rs` to export the new module and bind the components, and finally, added python tests in `tests_python/test_mahjong.py` to cover initialization, method operations, and Yaku evaluation through the Python bindings. Tests pass via `maturin develop` and `pytest`.

---
*PR created automatically by Jules for task [9621228958351070299](https://jules.google.com/task/9621228958351070299) started by @applyuser160*