### PR TITLE
🧪 Test River::push and River::pop

### DIFF
--- a/src/mahjong/river.rs
+++ b/src/mahjong/river.rs
@@ -23,3 +23,40 @@ impl River {
         self.tiles.pop()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_river_push() {
+        let mut river = River::new();
+        assert_eq!(river.tiles().len(), 0);
+
+        river.push(TileName::OneM);
+        assert_eq!(river.tiles().len(), 1);
+        assert_eq!(river.tiles()[0], TileName::OneM);
+
+        river.push(TileName::TwoP);
+        assert_eq!(river.tiles().len(), 2);
+        assert_eq!(river.tiles()[1], TileName::TwoP);
+    }
+
+    #[test]
+    fn test_river_pop() {
+        let mut river = River::new();
+        assert_eq!(river.pop(), None);
+
+        river.push(TileName::OneM);
+        river.push(TileName::TwoP);
+
+        assert_eq!(river.pop(), Some(TileName::TwoP));
+        assert_eq!(river.tiles().len(), 1);
+        assert_eq!(river.tiles()[0], TileName::OneM);
+
+        assert_eq!(river.pop(), Some(TileName::OneM));
+        assert_eq!(river.tiles().len(), 0);
+
+        assert_eq!(river.pop(), None);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `River::push` method in `src/mahjong/river.rs` was untested. This PR adds a `#[cfg(test)]` module with tests for `push` and `pop` to ensure proper behavior.
📊 **Coverage:** Added coverage for `River::push` and `River::pop` handling both empty and populated states, validating the length and specific contents.
✨ **Result:** Increased test reliability and coverage, providing a safety net for future refactoring.

---
*PR created automatically by Jules for task [16700742680596505668](https://jules.google.com/task/16700742680596505668) started by @applyuser160*