### PR TITLE
🔒 fix unsafe unwrap in Hand::call_meld

### DIFF
--- a/src/mahjong/hand.rs
+++ b/src/mahjong/hand.rs
@@ -105,7 +105,7 @@ impl Hand {
         // 消費された牌を手牌から取り除きます
         for &t in &consumed_from_hand {
             if let Some(pos) = self.tiles[..self.len].iter().position(|&x| x == t) {
-                self.discard(pos).unwrap();
+                self.discard(pos)?;
             }
         }
 


### PR DESCRIPTION
🎯 **What:** Fixed an unsafe `.unwrap()` call in `Hand::call_meld` when removing consumed tiles from the hand.
⚠️ **Risk:** If an unexpected internal state occurred where a tile that was supposed to be consumed was not actually present at a valid index, the `.unwrap()` call on `self.discard(pos)` would cause a hard panic, potentially leading to a denial-of-service or crashing the program unexpectedly.
🛡️ **Solution:** Replaced `.unwrap()` with `?` to safely propagate the `Result<TileName, &'static str>` returned by `self.discard` as the compatible `Result<(), &'static str>` expected by `Hand::call_meld`. This avoids panics and correctly returns an error upstream if an out-of-bounds operation occurs.

---
*PR created automatically by Jules for task [15703373168274826965](https://jules.google.com/task/15703373168274826965) started by @applyuser160*