### PR TITLE
⚡ Refactor pattern generation to use lazy evaluation

### DIFF
--- a/benches/mahjong_benchmark.rs
+++ b/benches/mahjong_benchmark.rs
@@ -33,7 +33,7 @@ fn bench_yaku(c: &mut Criterion) {
             judge_yaku(
                 black_box(complex_hand.tiles()),
                 black_box(&[] as &[Meld]),
-                black_box(complex_ctx.clone()),
+                black_box(complex_ctx),
             )
         })
     });
@@ -60,7 +60,7 @@ fn bench_yaku(c: &mut Criterion) {
             judge_yaku(
                 black_box(simple_hand.tiles()),
                 black_box(&[] as &[Meld]),
-                black_box(simple_ctx.clone()),
+                black_box(simple_ctx),
             )
         })
     });
@@ -93,7 +93,7 @@ fn bench_yaku(c: &mut Criterion) {
             judge_yaku(
                 black_box(open_hand.tiles()),
                 black_box(&open_melds),
-                black_box(open_ctx.clone()),
+                black_box(open_ctx),
             )
         })
     });
@@ -120,7 +120,7 @@ fn bench_yaku(c: &mut Criterion) {
             judge_yaku(
                 black_box(worst_case_hand.tiles()),
                 black_box(&[] as &[Meld]),
-                black_box(worst_case_ctx.clone()),
+                black_box(worst_case_ctx),
             )
         })
     });
@@ -147,7 +147,7 @@ fn bench_yaku(c: &mut Criterion) {
             judge_yaku(
                 black_box(no_yaku_hand.tiles()),
                 black_box(&[] as &[Meld]),
-                black_box(no_yaku_ctx.clone()),
+                black_box(no_yaku_ctx),
             )
         })
     });

--- a/src/mahjong/yaku.rs
+++ b/src/mahjong/yaku.rs
@@ -460,7 +460,7 @@ pub fn judge_yaku(
     open_melds_input: &[crate::hand::Meld],
     mut ctx: WinContext,
 ) -> HashSet<YakuId> {
-    let mut result = HashSet::new();
+    let result = HashSet::new();
 
     if tiles.is_empty() {
         return result;
@@ -553,109 +553,130 @@ pub fn judge_yaku(
     }
 
     // 手牌のパターン生成には、副露（鳴き）を除外した門前（メンゼン）の牌のみを使用します。
-    // そうしないと、副露した牌を再度パースしようとしてしまいます。
-    let patterns = generate_patterns(&closed_counts, &open_melds, &closed_melds);
+    let mut max_han = -1;
+    let mut best_yaku = HashSet::new();
 
-    result.extend(check_situational_yaku(&ctx));
+    let mut pattern_independent_yaku = HashSet::new();
+    pattern_independent_yaku.extend(check_situational_yaku(&ctx));
 
     let yakuman_list = check_yakuman_yaku(&counts, tiles.len());
     if !yakuman_list.is_empty() {
-        result.extend(yakuman_list);
-        retain_yakuman_only(&mut result);
-        return result;
-    }
-
-    if ctx.is_closed {
-        if has_ryanpeiko(&patterns) {
-            result.insert(YakuId::Ryanpeiko);
-        } else if has_ipeiko(&patterns) {
-            result.insert(YakuId::Ipeiko);
-        }
-    }
-
-    if is_chitoitsu(&counts) && ctx.is_closed && !result.contains(&YakuId::Ryanpeiko) {
-        result.insert(YakuId::Chitoitsu);
+        pattern_independent_yaku.extend(yakuman_list);
+        retain_yakuman_only(&mut pattern_independent_yaku);
+        return pattern_independent_yaku;
     }
 
     if is_tanyao(&counts) {
-        result.insert(YakuId::Tanyao);
+        pattern_independent_yaku.insert(YakuId::Tanyao);
     }
-
-    if let Some(y) = detect_pinfu(&patterns, &ctx) {
-        if y {
-            result.insert(YakuId::Pinfu);
-        }
-    }
-
-    if let Some(p) = patterns.first() {
-        if contains_yakuhai(&counts, ctx.seat_wind, ctx.round_wind) {
-            if counts[TileName::White as usize] >= 3 {
-                result.insert(YakuId::YakuhaiHaku);
-            }
-            if counts[TileName::Green as usize] >= 3 {
-                result.insert(YakuId::YakuhaiHatsu);
-            }
-            if counts[TileName::Red as usize] >= 3 {
-                result.insert(YakuId::YakuhaiChun);
-            }
-            if let Some(seat) = ctx.seat_wind {
-                let idx = seat as usize;
-                if counts[idx] >= 3 {
-                    result.insert(YakuId::YakuhaiJikaze);
-                }
-            }
-            if let Some(round) = ctx.round_wind {
-                let idx = round as usize;
-                if counts[idx] >= 3 {
-                    result.insert(YakuId::YakuhaiBakaze);
-                }
-            }
-        }
-
-        if is_toitoi(&patterns) {
-            result.insert(YakuId::Toitoi);
-        }
-        if is_sanankou(&patterns, &ctx) {
-            result.insert(YakuId::Sanankou);
-        }
-        if is_shousangen(p) {
-            result.insert(YakuId::Shousangen);
-        }
-        if is_chantaiyao(&patterns) {
-            result.insert(YakuId::Chantaiyao);
-        }
-        if has_sanshoku_doujun(&patterns) {
-            result.insert(YakuId::SanshokuDoujun);
-        }
-        if has_sanshoku_doukou(&patterns) {
-            result.insert(YakuId::SanshokuDoukou);
-        }
-        if is_junchan(&patterns) {
-            result.insert(YakuId::Junchan);
-        }
-        if ctx.kan_count >= 3 {
-            result.insert(YakuId::Sankantsu);
-        }
-        if ctx.kan_count >= 4 {
-            result.insert(YakuId::Suukantsu);
-        }
-        if is_suuankou(&patterns, ctx.is_closed, &ctx) {
-            result.insert(YakuId::Suuankou);
-        }
-    }
-
     if is_honitsu(&counts) {
-        result.insert(YakuId::Honitsu);
+        pattern_independent_yaku.insert(YakuId::Honitsu);
     }
     if is_chinitsu(&counts) {
-        result.insert(YakuId::Chinitsu);
+        pattern_independent_yaku.insert(YakuId::Chinitsu);
     }
     if is_honroutou(&counts) {
-        result.insert(YakuId::Honroutou);
+        pattern_independent_yaku.insert(YakuId::Honroutou);
     }
-    retain_yakuman_only(&mut result);
 
-    result
+    let mut yakuhai_yaku = Vec::new();
+    if contains_yakuhai(&counts, ctx.seat_wind, ctx.round_wind) {
+        if counts[TileName::White as usize] >= 3 {
+            yakuhai_yaku.push(YakuId::YakuhaiHaku);
+        }
+        if counts[TileName::Green as usize] >= 3 {
+            yakuhai_yaku.push(YakuId::YakuhaiHatsu);
+        }
+        if counts[TileName::Red as usize] >= 3 {
+            yakuhai_yaku.push(YakuId::YakuhaiChun);
+        }
+        if let Some(seat) = ctx.seat_wind {
+            let idx = seat as usize;
+            if counts[idx] >= 3 {
+                yakuhai_yaku.push(YakuId::YakuhaiJikaze);
+            }
+        }
+        if let Some(round) = ctx.round_wind {
+            let idx = round as usize;
+            if counts[idx] >= 3 {
+                yakuhai_yaku.push(YakuId::YakuhaiBakaze);
+            }
+        }
+    }
+
+    let mut kan_yaku = Vec::new();
+    if ctx.kan_count >= 3 {
+        kan_yaku.push(YakuId::Sankantsu);
+    }
+    if ctx.kan_count >= 4 {
+        kan_yaku.push(YakuId::Suukantsu);
+    }
+
+    let mut evaluate_yaku_set = |mut current_yaku: HashSet<YakuId>| {
+        retain_yakuman_only(&mut current_yaku);
+        let han = calculate_han(&current_yaku, ctx.is_closed);
+        if han > max_han {
+            max_han = han;
+            best_yaku = current_yaku;
+        }
+    };
+
+    generate_patterns(&closed_counts, &open_melds, &closed_melds, |pattern| {
+        let mut current_yaku = pattern_independent_yaku.clone();
+        current_yaku.extend(yakuhai_yaku.iter().copied());
+        current_yaku.extend(kan_yaku.iter().copied());
+
+        if ctx.is_closed {
+            if has_ryanpeiko(&pattern) {
+                current_yaku.insert(YakuId::Ryanpeiko);
+            } else if has_ipeiko(&pattern) {
+                current_yaku.insert(YakuId::Ipeiko);
+            }
+        }
+
+        if detect_pinfu(&pattern, &ctx) {
+            current_yaku.insert(YakuId::Pinfu);
+        }
+
+        if is_toitoi(&pattern) {
+            current_yaku.insert(YakuId::Toitoi);
+        }
+        if is_sanankou(&pattern, &ctx) {
+            current_yaku.insert(YakuId::Sanankou);
+        }
+        if is_shousangen(&pattern) {
+            current_yaku.insert(YakuId::Shousangen);
+        }
+        if is_chantaiyao(&pattern) {
+            current_yaku.insert(YakuId::Chantaiyao);
+        }
+        if has_sanshoku_doujun(&pattern) {
+            current_yaku.insert(YakuId::SanshokuDoujun);
+        }
+        if has_sanshoku_doukou(&pattern) {
+            current_yaku.insert(YakuId::SanshokuDoukou);
+        }
+        if is_junchan(&pattern) {
+            current_yaku.insert(YakuId::Junchan);
+        }
+        if is_suuankou(&pattern, ctx.is_closed, &ctx) {
+            current_yaku.insert(YakuId::Suuankou);
+        }
+
+        evaluate_yaku_set(current_yaku);
+    });
+
+    if is_chitoitsu(&counts) && ctx.is_closed && !best_yaku.contains(&YakuId::Ryanpeiko) {
+        let mut current_yaku = pattern_independent_yaku;
+        current_yaku.insert(YakuId::Chitoitsu);
+        retain_yakuman_only(&mut current_yaku);
+        let han = calculate_han(&current_yaku, ctx.is_closed);
+        if han > max_han {
+            best_yaku = current_yaku;
+        }
+    }
+
+    best_yaku
 }
 
 pub fn is_number_tile(tile: TileName) -> Option<(usize, usize)> {
@@ -747,12 +768,14 @@ fn is_simple(tile: TileName) -> bool {
     )
 }
 
-fn generate_patterns(
+fn generate_patterns<F>(
     counts: &[usize; 35],
     open_melds: &[MeldKind],
     closed_melds: &[MeldKind],
-) -> Vec<HandPattern> {
-    let mut patterns = Vec::new();
+    mut callback: F,
+) where
+    F: FnMut(HandPattern),
+{
     let mut current_melds = Vec::new();
 
     for i in 1..counts.len() {
@@ -766,24 +789,24 @@ fn generate_patterns(
         search_melds(
             &mut working,
             &mut current_melds,
-            &mut patterns,
             pair,
             open_melds,
             closed_melds,
+            &mut callback,
         );
     }
-
-    patterns
 }
 
-fn search_melds(
+fn search_melds<F>(
     counts: &mut [usize; 35],
     melds: &mut Vec<MeldKind>,
-    patterns: &mut Vec<HandPattern>,
     pair: TileName,
     open_melds: &[MeldKind],
     closed_melds: &[MeldKind],
-) {
+    callback: &mut F,
+) where
+    F: FnMut(HandPattern),
+{
     let Some(i) = counts
         .iter()
         .enumerate()
@@ -793,7 +816,7 @@ fn search_melds(
     else {
         let mut all_melds = closed_melds.to_vec();
         all_melds.extend_from_slice(melds);
-        patterns.push(HandPattern {
+        callback(HandPattern {
             pair,
             melds: all_melds,
             open_melds: open_melds.to_vec(),
@@ -806,7 +829,7 @@ fn search_melds(
     if counts[i] >= 3 {
         counts[i] -= 3;
         melds.push(MeldKind::Triplet(tile));
-        search_melds(counts, melds, patterns, pair, open_melds, closed_melds);
+        search_melds(counts, melds, pair, open_melds, closed_melds, callback);
         melds.pop();
         counts[i] += 3;
     }
@@ -839,7 +862,7 @@ fn search_melds(
     counts[next1] -= 1;
     counts[next2] -= 1;
     melds.push(MeldKind::Sequence(tile));
-    search_melds(counts, melds, patterns, pair, open_melds, closed_melds);
+    search_melds(counts, melds, pair, open_melds, closed_melds, callback);
     melds.pop();
     counts[i] += 1;
     counts[next1] += 1;
@@ -854,49 +877,49 @@ fn is_tanyao(counts: &[usize; 35]) -> bool {
         .all(|(i, count)| *count == 0 || is_simple(TileName::from_usize(i)))
 }
 
-fn has_ipeiko(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        let mut sequences: HashMap<TileName, usize> = HashMap::new();
-        for meld in pattern.all_melds() {
-            if let MeldKind::Sequence(tile) = meld {
-                *sequences.entry(*tile).or_default() += 1;
-            }
+fn has_ipeiko(pattern: &HandPattern) -> bool {
+    let mut sequences: HashMap<TileName, usize> = HashMap::new();
+    for meld in pattern.all_melds() {
+        if let MeldKind::Sequence(tile) = meld {
+            *sequences.entry(*tile).or_default() += 1;
         }
-        sequences.values().any(|v| *v >= 2)
-    })
+    }
+    sequences.values().any(|v| *v >= 2)
 }
 
-fn has_ryanpeiko(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        if pattern
-            .all_melds()
-            .any(|m| !matches!(m, MeldKind::Sequence(_)))
-        {
-            return false;
+fn has_ryanpeiko(pattern: &HandPattern) -> bool {
+    if pattern
+        .all_melds()
+        .any(|m| !matches!(m, MeldKind::Sequence(_)))
+    {
+        return false;
+    }
+    let mut sequences: HashMap<TileName, usize> = HashMap::new();
+    for meld in pattern.all_melds() {
+        if let MeldKind::Sequence(tile) = meld {
+            *sequences.entry(*tile).or_default() += 1;
         }
-        let mut sequences: HashMap<TileName, usize> = HashMap::new();
-        for meld in pattern.all_melds() {
-            if let MeldKind::Sequence(tile) = meld {
-                *sequences.entry(*tile).or_default() += 1;
-            }
-        }
-        let mut pairs = 0;
-        for value in sequences.values() {
-            pairs += value / 2;
-        }
-        pairs >= 2
-    })
+    }
+    let mut pairs = 0;
+    for value in sequences.values() {
+        pairs += value / 2;
+    }
+    pairs >= 2
 }
 
-fn detect_pinfu(patterns: &[HandPattern], ctx: &WinContext) -> Option<bool> {
+fn detect_pinfu(pattern: &HandPattern, ctx: &WinContext) -> bool {
     if !ctx.is_closed {
-        return Some(false);
+        return false;
     }
 
-    let win_tile = ctx.win_tile?;
-    let (win_suit, win_rank) = is_number_tile(win_tile)?;
+    let Some(win_tile) = ctx.win_tile else {
+        return false;
+    };
+    let Some((win_suit, win_rank)) = is_number_tile(win_tile) else {
+        return false;
+    };
 
-    for pattern in patterns {
+    for _ in 0..1 {
         if pattern
             .all_melds()
             .any(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)))
@@ -940,11 +963,11 @@ fn detect_pinfu(patterns: &[HandPattern], ctx: &WinContext) -> Option<bool> {
         });
 
         if is_ryamen {
-            return Some(true);
+            return true;
         }
     }
 
-    Some(false)
+    false
 }
 
 fn contains_yakuhai(
@@ -1002,36 +1025,32 @@ fn is_kokushi(counts: &[usize; 35]) -> bool {
     missing == 0 && has_pair
 }
 
-fn is_toitoi(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        pattern
-            .all_melds()
-            .all(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)))
-    })
+fn is_toitoi(pattern: &HandPattern) -> bool {
+    pattern
+        .all_melds()
+        .all(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)))
 }
 
-fn is_sanankou(patterns: &[HandPattern], ctx: &WinContext) -> bool {
-    patterns.iter().any(|pattern| {
-        let mut count = pattern
-            .melds
-            .iter()
-            .filter(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)))
-            .count();
+fn is_sanankou(pattern: &HandPattern, ctx: &WinContext) -> bool {
+    let mut count = pattern
+        .melds
+        .iter()
+        .filter(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)))
+        .count();
 
-        if !ctx.is_tsumo {
-            if let Some(win_tile) = ctx.win_tile {
-                // ロンアガリの牌が暗刻（アンコウ）を完成させた場合、それは明刻（ミンコウ）扱いになるため1を引きます
-                let matches_ron = pattern.melds.iter().any(|m| match m {
-                    MeldKind::Triplet(t) | MeldKind::Quad(t) => *t == win_tile,
-                    _ => false,
-                });
-                if matches_ron {
-                    count -= 1;
-                }
+    if !ctx.is_tsumo {
+        if let Some(win_tile) = ctx.win_tile {
+            // ロンアガリの牌が暗刻（アンコウ）を完成させた場合、それは明刻（ミンコウ）扱いになるため1を引きます
+            let matches_ron = pattern.melds.iter().any(|m| match m {
+                MeldKind::Triplet(t) | MeldKind::Quad(t) => *t == win_tile,
+                _ => false,
+            });
+            if matches_ron {
+                count -= 1;
             }
         }
-        count >= 3
-    })
+    }
+    count >= 3
 }
 
 fn is_shousangen(pattern: &HandPattern) -> bool {
@@ -1065,48 +1084,41 @@ fn is_daisangen(counts: &[usize; 35]) -> bool {
         && counts[TileName::White as usize] >= 3
 }
 
-fn is_chantaiyao(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        if !is_terminal_or_honor(pattern.pair) {
-            return false;
-        }
-
-        pattern.all_melds().all(|meld| match meld {
-            MeldKind::Sequence(tile) => matches!(is_number_tile(*tile), Some((_, 1 | 7))),
-            MeldKind::Triplet(tile) | MeldKind::Quad(tile) => is_terminal_or_honor(*tile),
-        })
+fn is_chantaiyao(pattern: &HandPattern) -> bool {
+    if !is_terminal_or_honor(pattern.pair) {
+        return false;
+    }
+    pattern.all_melds().all(|meld| match meld {
+        MeldKind::Sequence(tile) => matches!(is_number_tile(*tile), Some((_, 1 | 7))),
+        MeldKind::Triplet(tile) | MeldKind::Quad(tile) => is_terminal_or_honor(*tile),
     })
 }
 
-fn has_sanshoku_doujun(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        let mut map: HashMap<usize, HashSet<usize>> = HashMap::new();
-        for meld in pattern.all_melds() {
-            if let MeldKind::Sequence(tile) = meld {
+fn has_sanshoku_doujun(pattern: &HandPattern) -> bool {
+    let mut map: HashMap<usize, HashSet<usize>> = HashMap::new();
+    for meld in pattern.all_melds() {
+        if let MeldKind::Sequence(tile) = meld {
+            if let Some((suit, rank)) = is_number_tile(*tile) {
+                map.entry(rank).or_default().insert(suit);
+            }
+        }
+    }
+    map.values().any(|set| set.len() == 3)
+}
+
+fn has_sanshoku_doukou(pattern: &HandPattern) -> bool {
+    let mut map: HashMap<usize, HashSet<usize>> = HashMap::new();
+    for meld in pattern.all_melds() {
+        match meld {
+            MeldKind::Triplet(tile) | MeldKind::Quad(tile) => {
                 if let Some((suit, rank)) = is_number_tile(*tile) {
                     map.entry(rank).or_default().insert(suit);
                 }
             }
+            _ => {}
         }
-        map.values().any(|set| set.len() == 3)
-    })
-}
-
-fn has_sanshoku_doukou(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        let mut map: HashMap<usize, HashSet<usize>> = HashMap::new();
-        for meld in pattern.all_melds() {
-            match meld {
-                MeldKind::Triplet(tile) | MeldKind::Quad(tile) => {
-                    if let Some((suit, rank)) = is_number_tile(*tile) {
-                        map.entry(rank).or_default().insert(suit);
-                    }
-                }
-                _ => {}
-            }
-        }
-        map.values().any(|set| set.len() == 3)
-    })
+    }
+    map.values().any(|set| set.len() == 3)
 }
 
 fn is_honitsu(counts: &[usize; 35]) -> bool {
@@ -1150,15 +1162,13 @@ fn is_chinitsu(counts: &[usize; 35]) -> bool {
     suit_seen.is_some()
 }
 
-fn is_junchan(patterns: &[HandPattern]) -> bool {
-    patterns.iter().any(|pattern| {
-        if !is_terminal(pattern.pair) {
-            return false;
-        }
-        pattern.all_melds().all(|meld| match meld {
-            MeldKind::Sequence(tile) => matches!(is_number_tile(*tile), Some((_, 1 | 7))),
-            MeldKind::Triplet(tile) | MeldKind::Quad(tile) => is_terminal(*tile),
-        })
+fn is_junchan(pattern: &HandPattern) -> bool {
+    if !is_terminal(pattern.pair) {
+        return false;
+    }
+    pattern.all_melds().all(|meld| match meld {
+        MeldKind::Sequence(tile) => matches!(is_number_tile(*tile), Some((_, 1 | 7))),
+        MeldKind::Triplet(tile) | MeldKind::Quad(tile) => is_terminal(*tile),
     })
 }
 
@@ -1219,33 +1229,26 @@ fn is_ryuuiisou(counts: &[usize; 35]) -> bool {
         .all(|(i, c)| *c == 0 || allowed_set.contains(&i))
 }
 
-fn is_suuankou(patterns: &[HandPattern], closed: bool, ctx: &WinContext) -> bool {
-    closed
-        && patterns.iter().any(|pattern| {
-            let mut all_triplets = pattern
-                .melds
-                .iter()
-                .all(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)));
-
-            if all_triplets && !ctx.is_tsumo {
-                if let Some(win_tile) = ctx.win_tile {
-                    let completes_triplet = pattern.melds.iter().any(|m| match m {
-                        MeldKind::Triplet(t) | MeldKind::Quad(t) => *t == win_tile,
-                        _ => false,
-                    });
-
-                    if completes_triplet {
-                        // 四暗刻の場合、暗刻に対するロンアガリは「暗刻3＋明刻1」となり、四暗刻ではなく三暗刻・対々和になります。
-                        // ただし、単騎待ち（すでに暗刻が4つあり、雀頭を待つ形）の場合は例外です。
-                        // これを正確に判定するため、雀頭がロンアガリ牌であるかを検証します。
-                        if pattern.pair != win_tile {
-                            all_triplets = false;
-                        }
-                    }
-                }
+fn is_suuankou(pattern: &HandPattern, closed: bool, ctx: &WinContext) -> bool {
+    if !closed {
+        return false;
+    }
+    let mut all_triplets = pattern
+        .melds
+        .iter()
+        .all(|m| matches!(m, MeldKind::Triplet(_) | MeldKind::Quad(_)));
+    if all_triplets && !ctx.is_tsumo {
+        if let Some(win_tile) = ctx.win_tile {
+            let completes_triplet = pattern.melds.iter().any(|m| match m {
+                MeldKind::Triplet(t) | MeldKind::Quad(t) => *t == win_tile,
+                _ => false,
+            });
+            if completes_triplet && pattern.pair != win_tile {
+                all_triplets = false;
             }
-            all_triplets
-        })
+        }
+    }
+    all_triplets
 }
 
 fn is_chuuren_poutou(counts: &[usize; 35], tiles_len: usize) -> bool {
@@ -1374,4 +1377,25 @@ fn retain_yakuman_only(result: &mut std::collections::HashSet<YakuId>) {
                 .is_some_and(|y| y.yakuman)
         });
     }
+}
+
+fn calculate_han(yaku_set: &std::collections::HashSet<YakuId>, is_closed: bool) -> i32 {
+    let mut total_han = 0;
+    let mut has_yakuman = false;
+    for &id in yaku_set {
+        if let Some(yaku) = ALL_YAKU.iter().find(|y| y.id == id) {
+            total_han += if is_closed {
+                yaku.han_closed as i32
+            } else {
+                yaku.han_open as i32
+            };
+            if yaku.yakuman {
+                has_yakuman = true;
+            }
+        }
+    }
+    if has_yakuman {
+        total_han += 1000;
+    }
+    total_han
 }


### PR DESCRIPTION
💡 What
Refactored the yaku evaluation logic to use a lazy, callback-based approach for pattern generation instead of fully buffering all valid `HandPattern` variations into memory. `generate_patterns` now takes a closure, and `judge_yaku` uses this to evaluate the valid hand configurations iteratively, saving only the `YakuId` collection that produces the maximum total Han.

🎯 Why
By evaluating each hand configuration on the fly, we eliminate the need to heap-allocate and return large `Vec<HandPattern>` collections. This reduces memory footprint and computational overhead. Additionally, calculating the maximum Han explicitly per configuration ensures logical correctness according to Mahjong rules—preventing the prior bug where yaku from structurally incompatible parses could be merged together into the final outcome.

📊 Measured Improvement
Memory allocation during yaku evaluation has been minimized. `cargo bench` and `cargo test` report consistent or slightly improved execution times while successfully retaining correctness across all existing test vectors. Memory-intensive scenarios with heavy parsing branch trees see reduced overhead.

---
*PR created automatically by Jules for task [15586966122102940268](https://jules.google.com/task/15586966122102940268) started by @applyuser160*